### PR TITLE
[PFT-248] Change 'vm quota list' format for CLI

### DIFF
--- a/src/pfcli/vm.py
+++ b/src/pfcli/vm.py
@@ -55,7 +55,7 @@ def quota_list():
             elif header == "initial_quota":
                 quota_result = f"{quota_result} ({quota[header]})"
             elif header == "quota":
-                quota_result = str(quota[header]) + quota_result
+                quota_result = f"{quota[header]}{quota_result}"
         sub_result.append(quota_result)
         results.append(sub_result)
 


### PR DESCRIPTION
for 'vm instance type' in command `pf vm quota list`

- Change JSON format to a normal text format
- Delete id

**Before**
```
vm instance type                               initial quota    quota
-------------------------------------------  ---------------  -------
{                                                          1        1
  "id": 1,
  "name": "fai-azure-v100",
  "code": "fai-azure-v100",
  "vendor": "azure",
  "region": "eastus",
  "device_type": "V100"
}
{                                                          1        1
  "id": 2,
  "name": "AWS V100 us-east-2",
  "code": "aws-v100-us-east-2",
  "vendor": "aws",
  "region": "us-east-2",
  "device_type": "V100"
}
{                                                          1        1
  "id": 3,
  "name": "AWS V100 us-east-2a",
  "code": "aws-v100-us-east-2a",
  "vendor": "aws",
  "region": "us-east-2a",
  "device_type": "V100"
}
{                                                          1        1
  "id": 4,
  "name": "Azure A100-80GB southcentralus",
  "code": "azure-a100-80gb-southcentralus",
  "vendor": "azure",
  "region": "southcentralus",
  "device_type": "A100-80GB"
}
{                                                          1        2
  "id": 5,
  "name": "Azure A100 westus2",
  "code": "azure-a100-westus2",
  "vendor": "azure",
  "region": "westus2",
  "device_type": "A100"
}
```

**After**
```
╒══════════════════════════════════════╤═════════════════╤═════════╕
│ vm instance type                     │   initial quota │   quota │
╞══════════════════════════════════════╪═════════════════╪═════════╡
│ code: fai-azure-v100                 │               1 │       1 │
│ device_type: V100                    │                 │         │
│ name: fai-azure-v100                 │                 │         │
│ region: eastus                       │                 │         │
│ vendor: azure                        │                 │         │
├──────────────────────────────────────┼─────────────────┼─────────┤
│ code: aws-v100-us-east-2             │               1 │       1 │
│ device_type: V100                    │                 │         │
│ name: AWS V100 us-east-2             │                 │         │
│ region: us-east-2                    │                 │         │
│ vendor: aws                          │                 │         │
├──────────────────────────────────────┼─────────────────┼─────────┤
│ code: aws-v100-us-east-2a            │               1 │       1 │
│ device_type: V100                    │                 │         │
│ name: AWS V100 us-east-2a            │                 │         │
│ region: us-east-2a                   │                 │         │
│ vendor: aws                          │                 │         │
├──────────────────────────────────────┼─────────────────┼─────────┤
│ code: azure-a100-80gb-southcentralus │               1 │       1 │
│ device_type: A100-80GB               │                 │         │
│ name: Azure A100-80GB southcentralus │                 │         │
│ region: southcentralus               │                 │         │
│ vendor: azure                        │                 │         │
├──────────────────────────────────────┼─────────────────┼─────────┤
│ code: azure-a100-westus2             │               1 │      32 │
│ device_type: A100                    │                 │         │
│ name: Azure A100 westus2             │                 │         │
│ region: westus2                      │                 │         │
│ vendor: azure                        │                 │         │
╘══════════════════════════════════════╧═════════════════╧═════════╛
```
