### PR TITLE
[PFT-249] Change vm config view format in CLI

### DIFF
--- a/src/pfcli/vm.py
+++ b/src/pfcli/vm.py
@@ -106,7 +106,7 @@ def config_list():
 
 
 @config_app.command("view")
-def config_detail(vm_config_id: int = typer.Option(...), detail: bool = typer.Option(False, help="view all available fields for debugging purposes")):
+def config_detail(vm_config_id: int = typer.Option(...), detail: bool = typer.Option(False, help="View all available fields of vm configs")):
     response = autoauth.get(get_uri(f"vm_config/{vm_config_id}/"))
     try:
         response.raise_for_status()


### PR DESCRIPTION
for command `pf vm config view --vm-config-id 4`

- Change JSON format to a normal text format
- delete id

**Before**
```
id: 4
group id: 1
config type:
    id: 1
    name: FAI Azure US East V100
template data:
{
    "key": "value"
}
```

**After**
```
config type name: FAI Azure US East V100
group_id: 1
template_data:
    key: value
```