### PR TITLE
[PFT-251] Add template get command in CLI

### DIFF
--- a/src/pfcli/job.py
+++ b/src/pfcli/job.py
@@ -182,11 +182,17 @@ def template_list():
         r.raise_for_status()
         # TODO: Elaborate
         for template in r.json():
-            del(template['id'])
-            del(template['created_at'])
-            del(template['data_schema'])
-            typer.echo("---------------------------------------")
-            typer.echo(yaml.dump(template, sort_keys=False, indent=4))
+            prop_string = ""
+            for prop in template["data_schema"]["properties"]:
+                template["data_schema"]["properties"][prop] = f"{template['data_schema']['properties'][prop]['type']} ({template['data_example'][prop]})"
+            result = {
+                "name" : template["name"],
+                "model code" : template["model_code"],
+                "engine code" : template["engine_code"],
+                "data schema (example)" : template["data_schema"]["properties"]
+            }
+            typer.echo("------------------------------")
+            typer.echo(yaml.dump(result, sort_keys=False, indent=4))
     except HTTPError:
         secho_error_and_exit(f"Listing failed! Error Code = {r.status_code}, Detail = {r.text}")
 


### PR DESCRIPTION
template get command for getting a specific template for a specific name

` pf job template get --template-name 'Megatron-LM GPT-2' -f test2.txt `

**Specifications**

- can view details by template name on terminal

- can download as file (if add -f / --download-file option parameter) → details are not shown on terminal

```
name: AWS Megatron-LM GPT-2
model_code: gpt2-xl
engine_code: aws-megatron
data_example:
    lr: 0.00015
    min_lr: 1.0e-05
    adam_eps: 1.0e-08
    clip_grad: 1.0
    data_impl: mmap
    data_path: my-gpt2_text_document
    adam_beta1: 0.9
    adam_beta2: 0.999
    eval_iters: 10
    merge_file: gpt2-merges.txt
    num_layers: 24
    seq_length: 1024
    vocab_file: gpt2-vocab.json
    hidden_size: 1536
    train_iters: 1000000
    log_interval: 1
    weight_decay: 0.01
    eval_interval: 10000
    save_interval: 1000
    lr_decay_iters: 1000000
    lr_decay_style: linear
    lr_warmup_iters: 0
    micro_batch_size: 4
    global_batch_size: 16
    num_attention_heads: 16
```