### PR TITLE
Support multipart upload for large dataset (> 5GiB)

### DIFF
--- a/pfcli/datastore.py
+++ b/pfcli/datastore.py
@@ -24,7 +24,7 @@ from pfcli.service.client import (
     ProjectDataClientService,
     build_client,
 )
-from pfcli.service.client.data import get_mpu_targets, get_spu_targets
+from pfcli.service.client.data import FileSizeType, expand_paths
 from pfcli.service.cloud import build_storage_helper
 from pfcli.service.config import build_data_configurator
 from pfcli.service.formatter import (
@@ -254,26 +254,35 @@ def upload(
     datastore = project_client.create_datastore(name, StorageType.FAI, '', '', None, metadata, [], False)
     datastore_id = datastore['id']
 
-    typer.echo(f"Start uploading objects to datastore ({name})...")
-    spu_targets = get_spu_targets(source_path, expand)
-    mpu_targets = get_mpu_targets(source_path, expand)
-    spu_url_dicts = client.get_spu_urls(datastore_id=datastore_id, paths=spu_targets) if len(spu_targets) > 0 else []
-    mpu_url_dicts = client.get_mpu_urls(datastore_id=datastore_id, paths=mpu_targets) if len(mpu_targets) > 0 else []
+    try:
+        typer.echo(f"Start uploading objects to datastore ({name})...")
+        spu_targets = expand_paths(source_path, expand, FileSizeType.SMALL)
+        mpu_targets = expand_paths(source_path, expand, FileSizeType.LARGE)
+        spu_url_dicts = client.get_spu_urls(datastore_id=datastore_id, paths=spu_targets) if len(spu_targets) > 0 else []
+        mpu_url_dicts = client.get_mpu_urls(
+            datastore_id=datastore_id,
+            paths=mpu_targets,
+            src_path=source_path.name if expand else None
+        ) if len(mpu_targets) > 0 else []
 
-    client.upload_files(datastore_id, spu_url_dicts, mpu_url_dicts, source_path, expand)
+        client.upload_files(datastore_id, spu_url_dicts, mpu_url_dicts, source_path, expand)
 
-    files = [
-        get_file_info(url_info['path'], source_path, expand) for url_info in spu_url_dicts
-    ]
-    files.extend([
-        get_file_info(url_info['path'], source_path, expand) for url_info in mpu_url_dicts
-    ])
-    datastore = client.update_datastore(
-        datastore_id,
-        files=files,
-        metadata=metadata,
-        active=True
-    )
+        files = [
+            get_file_info(url_info['path'], source_path, expand) for url_info in spu_url_dicts
+        ]
+        files.extend([
+            get_file_info(url_info['path'], source_path, expand) for url_info in mpu_url_dicts
+        ])
+        datastore = client.update_datastore(
+            datastore_id,
+            files=files,
+            metadata=metadata,
+            active=True
+        )
+    except Exception as exc:
+        client.delete_datastore(datastore_id)
+        raise exc
+
     datastore['vendor'] = storage_type_map_inv[datastore['vendor']].value
 
     typer.secho(f"Objects are uploaded to datastore ({name}) successfully!", fg=typer.colors.BLUE)

--- a/pfcli/job.py
+++ b/pfcli/job.py
@@ -55,7 +55,7 @@ template_app = typer.Typer(
     add_completion=False
 )
 
-app.add_typer(template_app, name="template", help="Manager job templates.")
+app.add_typer(template_app, name="template", help="Manage job templates.")
 
 job_table = TableFormatter(
     name="Jobs",

--- a/pfcli/service/client/data.py
+++ b/pfcli/service/client/data.py
@@ -2,13 +2,26 @@
 
 """PeriFlow DataClient Service"""
 
-
+import math
+import os
+from concurrent.futures import ThreadPoolExecutor, wait, FIRST_EXCEPTION
+from functools import wraps
 from pathlib import Path
 from typing import Dict, List, Optional
 
+import requests
+from requests import Request, Session
+from tqdm import tqdm
+from tqdm.utils import CallbackIOWrapper
+
 from pfcli.service import StorageType, storage_type_map_inv
 from pfcli.service.client.base import ClientService, T, safe_request
-from pfcli.utils import secho_error_and_exit, validate_storage_region
+from pfcli.utils import secho_error_and_exit, storage_path_to_local_path, validate_storage_region
+
+# The actual hard limit of a part size is 5 GiB, and we use 200 MiB part size.
+# See https://docs.aws.amazon.com/AmazonS3/latest/userguide/qfacts.html.
+S3_MPU_PART_MAX_SIZE = 200 * 1024 * 1024        # 200 MiB
+S3_UPLOAD_SIZE_LIMIT = 5 * 1024 * 1024 * 1024   # 5 GiB
 
 
 class DataClientService(ClientService):
@@ -65,18 +78,225 @@ class DataClientService(ClientService):
             pk=datastore_id
         )
 
-    def get_upload_urls(self, datastore_id: T, src_path: Path, expand: bool) -> List[Dict[str, str]]:
-        if src_path.is_file():
-            paths = [str(src_path.name)]
-        else:
-            paths = list(src_path.rglob('*'))
-            rel_path = src_path if expand else src_path.parent
-            paths = [str(f.relative_to(rel_path)) for f in paths if f.is_file()]
-        if len(paths) == 0:
-            secho_error_and_exit(f"No file exists in this path ({src_path})")
+    def get_spu_urls(self, datastore_id: T, paths: List[str]) -> List[dict]:
+        """Get single part upload URLs for multiple files.
 
+        Args:
+            datastore_id (T): _description_
+            paths (List[str]): _description_
+
+        Returns:
+            List[dict]: _description_
+        """
         response = safe_request(self.post, err_prefix="Failed to get presigned URLs.")(
             path=f"{datastore_id}/upload/",
             json={"paths": paths}
         )
         return response.json()
+
+    def get_mpu_urls(self, datastore_id: T, paths: List[str]) -> List[dict]:
+        """Get multipart upload URLs for multiple datasets
+
+        Args:
+            datastore_id (T): The ID of dataset
+            paths (List[str]): A list of upload target paths
+
+        Returns:
+            List[dict]: A list of multipart upload responses for multiple target files.
+            {
+                "path": "string",
+                "upload_id": "string",
+                "upload_urls": [
+                    {
+                        "upload_url": "string",
+                        "part_number": 0
+                    }
+                ]
+            }
+        """
+        start_mpu_resps = []
+        for path in paths:
+            num_parts = math.ceil(get_file_size(path) / S3_MPU_PART_MAX_SIZE)
+            response = safe_request(self.post, err_prefix="Failed to get presigned URLs for multipart upload.")(
+                path=f"{datastore_id}/start_mpu/",
+                json={
+                    "path": path,
+                    "num_parts": num_parts,
+                }
+            )
+            start_mpu_resps.append(response.json())
+        return start_mpu_resps
+
+    def complete_mpu(self, datastore_id: T, path: str, upload_id: str, parts: List[dict]) -> None:
+        safe_request(self.post, err_prefix=f"Failed to complete multipart upload for {path}")(
+            path=f"{datastore_id}/complete_mpu/",
+            json={
+                "path": path,
+                "upload_id": upload_id,
+                "parts": parts,
+            }
+        )
+
+    def abort_mpu(self, datastore_id: T, path: str, upload_id: str) -> None:
+        safe_request(self.post, err_prefix=f"Failed to abort multipart upload for {path}")(
+            path=f"{datastore_id}/abort_mpu/",
+            json={
+                "path": path,
+                "upload_id": upload_id,
+            }
+        )
+
+    def _multipart_upload_file(
+        self,
+        datastore_id: T,
+        file_path: str,
+        urls: List[str],
+        upload_id: str,
+        ctx: tqdm
+    ) -> None:
+        parts = []
+        try:
+            with open(file_path, 'rb') as f:
+                fileno = f.fileno()
+                total_file_size = os.fstat(fileno).st_size
+                for idx, url_info in enumerate(urls):
+                    cursor = idx * S3_MPU_PART_MAX_SIZE
+                    f.seek(cursor)
+                    chunk_size = S3_MPU_PART_MAX_SIZE if idx < len(urls) - 1 else total_file_size - cursor
+                    wrapped_object = _CustomCallbackIOWrapper(ctx.update, f, 'read', chunk_size)
+                    s = Session()
+                    req = Request('PUT', url_info['upload_url'], data=wrapped_object)
+                    prep = req.prepare()
+                    prep.headers['Content-Length'] = chunk_size
+                    response = s.send(prep)
+
+                    etag = response.headers['ETag']
+                    parts.append(
+                        {
+                            'etag': etag,
+                            'part_number': url_info['part_number'],
+                        }
+                    )
+                assert not f.read(S3_MPU_PART_MAX_SIZE)
+            self.complete_mpu(datastore_id, file_path, upload_id, parts)
+        except FileNotFoundError:
+            secho_error_and_exit(f"{file_path} is not found.")
+        except Exception:
+            self.abort_mpu(datastore_id, file_path, upload_id)
+            secho_error_and_exit("File upload is aborted.")
+
+    def upload_files(
+        self,
+        datastore_id: T,
+        spu_url_dicts: List[Dict[str, str]],
+        mpu_url_dicts: List[dict],
+        source_path: Path,
+        expand: bool,
+    ) -> None:
+        spu_local_paths = [
+            storage_path_to_local_path(url_info['path'], source_path, expand) for url_info in spu_url_dicts
+        ]
+        mpu_local_paths = [
+            storage_path_to_local_path(url_info['path'], source_path, expand) for url_info in mpu_url_dicts
+        ]
+        total_size = get_total_file_size(spu_local_paths + mpu_local_paths)
+        spu_urls = [ url_info['upload_url'] for url_info in spu_url_dicts ]
+        mpu_urls = [ url_info['upload_urls'] for url_info in mpu_url_dicts ]
+        mpu_upload_ids = [ url_info['upload_id'] for url_info in mpu_url_dicts ]
+
+        with tqdm(total=total_size, unit='B', unit_scale=True, unit_divisor=1024) as t:
+            with ThreadPoolExecutor() as executor:
+                # Normal upload for files with size < 5 GiB
+                futs = [
+                    executor.submit(
+                        _upload_file, local_path, upload_url, t
+                    ) for (local_path, upload_url) in zip(spu_local_paths, spu_urls)
+                ]
+                # Multipart upload for large files with sizes >= 5 GiB
+                futs.extend([
+                    executor.submit(
+                        self._multipart_upload_file, datastore_id, local_path, upload_urls, upload_id, t
+                    ) for (local_path, upload_urls, upload_id) in zip(mpu_local_paths, mpu_urls, mpu_upload_ids)
+                ])
+                wait(futs, return_when=FIRST_EXCEPTION)
+                for fut in futs:
+                    exc = fut.exception()
+                    if exc is not None:
+                        raise exc
+
+
+def expand_paths(path: Path, expand: bool) -> List[str]:
+    if path.is_file():
+        paths = [str(path.name)]
+    else:
+        paths = list(path.rglob('*'))
+        rel_path = path if expand else path.parent
+        paths = [str(f.relative_to(rel_path)) for f in paths if f.is_file()]
+
+    return paths
+
+
+def get_spu_targets(src_path: Path, expand: bool) -> List[str]:
+    return [ path for path in expand_paths(src_path, expand) if get_file_size(path) < S3_UPLOAD_SIZE_LIMIT ]
+
+
+def get_mpu_targets(src_path: Path, expand: bool) -> List[str]:
+    return [ path for path in expand_paths(src_path, expand) if get_file_size(path) >= S3_UPLOAD_SIZE_LIMIT ]
+
+
+def _upload_file(file_path: str, url: str, ctx: tqdm) -> None:
+    try:
+        with open(file_path, 'rb') as f:
+            fileno = f.fileno()
+            total_file_size = os.fstat(fileno).st_size
+            wrapped_object = CallbackIOWrapper(ctx.update, f, 'read')
+            s = Session()
+            req = Request('PUT', url, data=wrapped_object)
+            prep = req.prepare()
+            prep.headers['Content-Length'] = total_file_size    # necessary to use ``CallbackIOWrapper``
+            s.send(prep)
+    except FileNotFoundError:
+        secho_error_and_exit(f"{file_path} is not found.")
+
+
+def get_file_size(file_path: str) -> int:
+    return os.stat(file_path).st_size
+
+
+def get_total_file_size(file_paths: List[str]) -> int:
+    return sum([ get_file_size(file_path) for file_path in file_paths ])
+
+
+class _CustomCallbackIOWrapper(CallbackIOWrapper):
+    def __init__(self, callback, stream, method="read", chunk_size=None):
+        """
+        Wrap a given `file`-like object's `read()` or `write()` to report
+        lengths to the given `callback`
+        """
+        super().__init__(callback, stream, method)
+        self._chunk_size = chunk_size
+        self._cursor = 0
+
+        func = getattr(stream, method)
+        if method == "write":
+            @wraps(func)
+            def write(data, *args, **kwargs):
+                res = func(data, *args, **kwargs)
+                callback(len(data))
+                return res
+            self.wrapper_setattr('write', write)
+        elif method == "read":
+            @wraps(func)
+            def read(*args, **kwargs):
+                if self._cursor >= chunk_size:
+                    self._cursor = 0
+                    return
+
+                data = func(*args, **kwargs)
+                data_size = len(data)
+                callback(data_size)
+                self._cursor += data_size
+                return data
+            self.wrapper_setattr('read', read)
+        else:
+            raise KeyError("Can only wrap read/write methods")

--- a/test/service/client/test_data.py
+++ b/test/service/client/test_data.py
@@ -2,6 +2,7 @@
 
 """Test DataClient Service"""
 
+import os
 from copy import deepcopy
 from pathlib import Path
 from tempfile import TemporaryDirectory
@@ -12,7 +13,13 @@ import typer
 
 from pfcli.service import ServiceType, StorageType
 from pfcli.service.client import build_client
-from pfcli.service.client.data import DataClientService
+from pfcli.service.client.data import S3_MPU_PART_MAX_SIZE, S3_UPLOAD_SIZE_LIMIT, DataClientService
+
+
+def write_file(path: str, size: int) -> None:
+    with open(path, 'wb') as f:
+        f.seek(size - 1)
+        f.write(b'\0')
 
 
 @pytest.fixture
@@ -112,7 +119,7 @@ def test_data_client_delete_datastore(requests_mock: requests_mock.Mocker, data_
 
 
 @pytest.mark.usefixtures('patch_auto_token_refresh')
-def test_data_client_get_upload_urls(requests_mock: requests_mock.Mocker, data_client: DataClientService):
+def test_data_client_get_spu_urls(requests_mock: requests_mock.Mocker, data_client: DataClientService):
     assert isinstance(data_client, DataClientService)
 
     url_template = deepcopy(data_client.url_template)
@@ -125,25 +132,213 @@ def test_data_client_get_upload_urls(requests_mock: requests_mock.Mocker, data_c
             {'path': '/path/to/local/file', 'upload_url': 'https://s3.bucket.com'}
         ]
     )
-    with TemporaryDirectory() as dir:
-        (Path(dir) / 'file').touch()
-        assert data_client.get_upload_urls(0, Path(dir), True) == [
-            {'path': '/path/to/local/file', 'upload_url': 'https://s3.bucket.com'}
-        ]
-
-        # Handle a single file
-        assert data_client.get_upload_urls(0, Path(dir) / 'file', True) == [
-            {'path': '/path/to/local/file', 'upload_url': 'https://s3.bucket.com'}
-        ]
-
-    # Failed when uploading empty directory.
-    with TemporaryDirectory() as dir:
-        with pytest.raises(typer.Exit):
-            data_client.get_upload_urls(0, Path(dir), True)
+    assert data_client.get_spu_urls(0, ['/path/to/local/file']) == [
+        {'path': '/path/to/local/file', 'upload_url': 'https://s3.bucket.com'}
+    ]
 
     # Failed due to HTTP error
     requests_mock.post(url_template.render(datastore_id=0), status_code=500)
-    with TemporaryDirectory() as dir:
-        (Path(dir) / 'file').touch()
+    with pytest.raises(typer.Exit):
+        data_client.get_spu_urls(0, ['/path/to/local/file'])
+
+
+@pytest.mark.usefixtures('patch_auto_token_refresh')
+def test_data_client_get_mpu_urls(requests_mock: requests_mock.Mocker, data_client: DataClientService):
+    assert isinstance(data_client, DataClientService)
+
+    url_template = deepcopy(data_client.url_template)
+    url_template.attach_pattern('$datastore_id/start_mpu/')
+
+    with TemporaryDirectory() as temp_dir:
+        target_file_path = os.path.join(temp_dir, 'large_file')
+        resp_mock = {
+            'path': target_file_path,
+            'upload_id': '865b8d498d1fb82e92a7e808e82c4111',
+            'upload_urls': [
+                {
+                    'upload_url': 'https://mydata.s3.amazonaws.com/path/to/file/part1',
+                    'part_number': 1
+                },
+                {
+                    'upload_url': 'https://mydata.s3.amazonaws.com/path/to/file/part2',
+                    'part_number': 2
+                }
+            ]
+        }
+        write_file(target_file_path, S3_UPLOAD_SIZE_LIMIT * 2)
+
+        requests_mock.post(
+            url_template.render(datastore_id=0),
+            json=resp_mock
+        )
+        assert data_client.get_mpu_urls(0, [target_file_path]) == [resp_mock]
+
+        requests_mock.post(url_template.render(datastore_id=0), status_code=500)
         with pytest.raises(typer.Exit):
-            data_client.get_upload_urls(0, Path(dir), True)
+            data_client.get_mpu_urls(0, [target_file_path])
+
+
+@pytest.mark.usefixtures('patch_auto_token_refresh')
+def test_data_client_complete_mpu(requests_mock: requests_mock.Mocker, data_client: DataClientService):
+    assert isinstance(data_client, DataClientService)
+
+    url_template = deepcopy(data_client.url_template)
+    url_template.attach_pattern('$datastore_id/complete_mpu/')
+
+    requests_mock.post(url_template.render(datastore_id=0))
+    data_client.complete_mpu(
+        0,
+        ['/path/to/file'],
+        'fakeuploadid',
+        {
+            'part': [
+                {'etag': 'fakeetag', 'part_number': 1},
+                {'etag': 'fakeetag', 'part_number': 2},
+            ],
+        },
+    )
+
+    requests_mock.post(url_template.render(datastore_id=0), status_code=500)
+    with pytest.raises(typer.Exit):
+        data_client.complete_mpu(
+            0,
+            ['/path/to/file'],
+            'fakeuploadid',
+            {
+                'part': [
+                    {'etag': 'fakeetag', 'part_number': 1},
+                    {'etag': 'fakeetag', 'part_number': 2},
+                ],
+            },
+        )
+
+
+@pytest.mark.usefixtures('patch_auto_token_refresh')
+def test_data_client_abort_mpu(requests_mock: requests_mock.Mocker, data_client: DataClientService):
+    assert isinstance(data_client, DataClientService)
+
+    url_template = deepcopy(data_client.url_template)
+    url_template.attach_pattern('$datastore_id/abort_mpu/')
+
+    requests_mock.post(url_template.render(datastore_id=0))
+    data_client.abort_mpu(
+        0,
+        ['/path/to/file'],
+        'fakeuploadid',
+    )
+
+    requests_mock.post(url_template.render(datastore_id=0), status_code=500)
+    with pytest.raises(typer.Exit):
+        data_client.abort_mpu(
+            0,
+            ['/path/to/file'],
+            'fakeuploadid',
+        )
+
+
+def test_upload_small_files(requests_mock: requests_mock.Mocker, data_client: DataClientService):
+    assert isinstance(data_client, DataClientService)
+    fake_upload_url = 'https://mybucket.s3.amazon.com'
+
+    with TemporaryDirectory() as tmp_dir:
+        path = os.path.join(tmp_dir, 'small_file')
+        write_file(path, 1024)
+
+        # Success
+        requests_mock.put(fake_upload_url)
+        data_client.upload_files(
+            datastore_id=0,
+            spu_url_dicts=[
+                {
+                    'path': 'small_file',
+                    'upload_url': fake_upload_url,
+                }
+            ],
+            mpu_url_dicts=[],
+            source_path=Path(tmp_dir),
+            expand=True,
+        )
+
+        # Upload failed
+        requests_mock.put(fake_upload_url, status_code=400)
+        with pytest.raises(typer.Exit):
+            data_client.upload_files(
+                datastore_id=0,
+                spu_url_dicts=[
+                    {
+                        'path': 'small_file',
+                        'upload_url': fake_upload_url,
+                    }
+                ],
+                mpu_url_dicts=[],
+                source_path=Path(tmp_dir),
+                expand=True,
+            )
+
+
+def test_upload_large_files(requests_mock: requests_mock.Mocker, data_client: DataClientService):
+    assert isinstance(data_client, DataClientService)
+    fake_upload_url = 'https://mybucket.s3.amazon.com'
+
+    url_template = deepcopy(data_client.url_template)
+    url_template.attach_pattern('$datastore_id/abort_mpu/')
+    requests_mock.post(url_template.render(datastore_id=0))
+
+    url_template = deepcopy(data_client.url_template)
+    url_template.attach_pattern('$datastore_id/complete_mpu/')
+    requests_mock.post(url_template.render(datastore_id=0))
+
+    with TemporaryDirectory() as tmp_dir:
+        path = os.path.join(tmp_dir, 'large_file')
+        write_file(path, S3_MPU_PART_MAX_SIZE)      # This is hack to pass assertion
+
+        # Success
+        requests_mock.put(fake_upload_url, headers={'ETag': 'fakeetag'})
+        data_client.upload_files(
+            datastore_id=0,
+            spu_url_dicts=[],
+            mpu_url_dicts=[
+                {
+                    'path': 'large_file',
+                    'upload_id': 'uploadid1',
+                    'upload_urls': [
+                        {
+                            'upload_url': fake_upload_url,
+                            'part_number': 1,
+                        },
+                        {
+                            'upload_url': fake_upload_url,
+                            'part_number': 2,
+                        },
+                    ]
+                },
+            ],
+            source_path=Path(tmp_dir),
+            expand=True,
+        )
+
+        # Upload failed
+        requests_mock.put(fake_upload_url, status_code=400)
+        with pytest.raises(typer.Exit):
+            data_client.upload_files(
+                datastore_id=0,
+                spu_url_dicts=[],
+                mpu_url_dicts=[
+                    {
+                        'path': 'large_file',
+                        'upload_id': 'uploadid1',
+                        'upload_urls': [
+                            {
+                                'upload_url': fake_upload_url,
+                                'part_number': 1,
+                            },
+                            {
+                                'upload_url': fake_upload_url,
+                                'part_number': 2,
+                            },
+                        ]
+                    },
+                ],
+                source_path=Path(tmp_dir),
+                expand=True,
+            )


### PR DESCRIPTION
# PR Description

Currently `pf datastore upload` silently fails to upload files larger than 5 GiB. This is due to the S3 file upload restriction.
This PR enables the large dataset (> 5 GiB) upload with `pf datastore upload`.

If the size of a single file is larger than 5 GiB, which is the part size limit of S3, the file is uploaded with using a multipart upload API. Otherwise, the existing upload API will be used. Note that each part size of multipart upload is 200 MiB.

## TODO

We are going to optimize the multipart upload in the next update by parallelizing each part upload.