### PR TITLE
[PF-558] show workspace structure

### DIFF
--- a/pfcli/service/client/project.py
+++ b/pfcli/service/client/project.py
@@ -103,6 +103,7 @@ class ProjectJobClientService(ClientService, ProjectRequestMixin):
     def run_job(self, config: dict, workspace_dir: Optional[Path]) -> dict:
         job_request = safe_request(self.post, err_prefix="Failed to run job.")
         if workspace_dir is not None:
+            typer.secho("Preparing workspace directory...", fg=typer.colors.MAGENTA)
             workspace_dir = workspace_dir.resolve()
             workspace_files = get_workspace_files(workspace_dir)
             workspace_size = sum(f.stat().st_size for f in workspace_files)
@@ -115,8 +116,8 @@ class ProjectJobClientService(ClientService, ProjectRequestMixin):
                 root=os.path.join(config["job_setting"]["workspace"]["mount_path"], workspace_dir.name)
             )
             typer.secho(
-                "Workspace is uploaded and will be mounted as the following structure.",
-                fg=typer.colors.BLUE
+                "Workspace is prepared and will be mounted as the following structure.",
+                fg=typer.colors.MAGENTA
             )
             tree_formatter.render(
                 [

--- a/pfcli/service/client/project.py
+++ b/pfcli/service/client/project.py
@@ -111,7 +111,7 @@ class ProjectJobClientService(ClientService, ProjectRequestMixin):
                     f"Workspace directory size ({decimal(workspace_size)}) should be 0 < size <= 100MB."
                 )
             tree_formatter = TreeFormatter(
-                name="Workspace Files",
+                name="Job Workspace",
                 root=os.path.join(config["job_setting"]["workspace"]["mount_path"], workspace_dir.name)
             )
             typer.secho(

--- a/pfcli/service/formatter.py
+++ b/pfcli/service/formatter.py
@@ -3,6 +3,7 @@
 """PeriFlow CLI Output Formatter"""
 
 import json
+import os
 import re
 from dataclasses import dataclass, field
 from typing import (
@@ -212,8 +213,9 @@ def find_and_insert(parent: Tree, edges: List[Edge]) -> None:
 class TreeFormatter(Formatter):
     """Tree formatter for visualizing file tree."""
 
-    def __post_init__(self):
-        super().__post_init__()
+    def __init__(self, name: str, root: str = ""):
+        super().__init__(name=name)
+        self._root = "/" + root.lstrip("/")
 
     def render(self, data: List[dict]) -> None:
         self._build_renderable(data)
@@ -225,7 +227,10 @@ class TreeFormatter(Formatter):
 
     def _build_tree(self, data: List[dict]) -> Tree:
         root = Tree("/")
-        paths = [f"/{d['path'].lstrip()}" for d in data]
+        paths = [
+            f"{d['path']}" if os.path.isabs(d['path']) \
+            else f"{os.path.join(self._root, d['path'])}" for d in data
+        ]
         sizes = [d["size"] for d in data]
         for path, size in zip(paths, sizes):
             edges = []

--- a/pfcli/utils.py
+++ b/pfcli/utils.py
@@ -131,7 +131,6 @@ def datetime_to_simple_string(dt: datetime) -> str:
 
 @contextmanager
 def zip_dir(base_path: Path, target_files: List[Path], zip_path: Path):
-    typer.secho("Preparing workspace directory...", fg=typer.colors.MAGENTA)
     with zipfile.ZipFile(zip_path, "w", zipfile.ZIP_STORED) as zip_file:
         for file in target_files:
             zip_file.write(file, file.relative_to(base_path.parent))

--- a/test/service/client/test_project.py
+++ b/test/service/client/test_project.py
@@ -178,7 +178,13 @@ def test_project_job_client_run_job(
         with open(ws_dir / "large_file", "wb") as f:
             f.seek(500 * 1024)  # 500KB
             f.write(b"0")
-        assert project_job_client.run_job({"k": "v"}, ws_dir) == {"id": 1}
+        assert project_job_client.run_job(
+            {
+                "job_setting": {
+                    "workspace": {
+                        "mount_path": "/workspace"
+                }
+            }, "k": "v"}, ws_dir) == {"id": 1}
 
     # Failed due to large workspace dir exceeding the size limit
     with TemporaryDirectory() as dir:


### PR DESCRIPTION
Running a job will now show

<img width="1633" alt="스크린샷 2022-09-12 오전 11 10 34" src="https://user-images.githubusercontent.com/19629048/189561825-ffd68cc3-4850-4dc7-96e1-c83d90fa6322.png">
