### PR TITLE
support job metrics command

### DIFF
--- a/pfcli/job.py
+++ b/pfcli/job.py
@@ -644,6 +644,14 @@ def show_metrics(
         )
 
     client: MetricsClientService = build_client(ServiceType.METRICS)
+    metrics_set = []
     for metric_name in name:
         metrics = client.get_metrics_values(job_id, metric_name, limit)
+        if not len(metrics):
+            secho_error_and_exit(
+                f"There is no available metrics with name '{metric_name}'."
+            )
+        metrics_set.append(metrics)
+
+    for metrics in metrics_set:
         metrics_table.render(metrics)

--- a/pfcli/job.py
+++ b/pfcli/job.py
@@ -158,8 +158,8 @@ metrics_list_table = TableFormatter(
 )
 metrics_table = TableFormatter(
     name="Metrics",
-    fields=["name", "created", "value"],
-    headers=["Name", "Created", "Value"],
+    fields=["name", "iteration", "created", "value"],
+    headers=["Name", "Iteration", "Created", "Value"],
 )
 
 
@@ -635,9 +635,15 @@ def metrics_list(
 def show_metrics(
     job_id: int = typer.Argument(..., help="ID of job"),
     name: List[str] = typer.Option(..., help="metrics name"),
+    limit: int = typer.Option(10, help="Number of metrics to show"),
 ):
-    """Show metrics values"""
+    """Show latest metrics values"""
+    if limit <= 0 or limit > 1000:
+        secho_error_and_exit(
+            "'limit' should be a positive integer, equal or smaller than 1000"
+        )
+
     client: MetricsClientService = build_client(ServiceType.METRICS)
     for metric_name in name:
-        metrics = client.get_metrics_values(job_id, metric_name)
+        metrics = client.get_metrics_values(job_id, metric_name, limit)
         metrics_table.render(metrics)

--- a/pfcli/job.py
+++ b/pfcli/job.py
@@ -11,7 +11,7 @@ from dateutil.parser import parse
 from datetime import datetime
 
 import tabulate
-from pfcli.service.client.metric import MetricClientService
+from pfcli.service.client.metrics import MetricsClientService
 import typer
 import yaml
 import ruamel.yaml
@@ -55,14 +55,14 @@ template_app = typer.Typer(
     context_settings={"help_option_names": ["-h", "--help"]},
     add_completion=False,
 )
-metric_app = typer.Typer(
+metrics_app = typer.Typer(
     no_args_is_help=True,
     context_settings={"help_option_names": ["-h", "--help"]},
     add_completion=False,
 )
 
 app.add_typer(template_app, name="template", help="Manage job templates.")
-app.add_typer(metric_app, name="metric", help="Show job metrics.")
+app.add_typer(metrics_app, name="metrics", help="Show job metrics.")
 
 job_table = TableFormatter(
     name="Jobs",
@@ -151,12 +151,12 @@ artifact_table = TableFormatter(
     fields=["id", "name", "path", "mtime", "mime_type"],
     headers=["ID", "Name", "Path", "Mtime", "Media Type"],
 )
-metric_list_table = TableFormatter(
-    name="Metric List",
+metrics_list_table = TableFormatter(
+    name="Metrics List",
     fields=["name"],
     headers=["Name"],
 )
-metric_table = TableFormatter(
+metrics_table = TableFormatter(
     name="Metrics",
     fields=["name", "created", "value"],
     headers=["Name", "Created", "Value"],
@@ -621,23 +621,23 @@ def log(
             secho_error_and_exit(f"Keyboard Interrupt...", color=typer.colors.MAGENTA)
 
 
-@metric_app.command("list")
-def metric_list(
+@metrics_app.command("list")
+def metrics_list(
     job_id: int = typer.Argument(..., help="ID of job"),
 ):
     """Show all available metric names"""
-    client: MetricClientService = build_client(ServiceType.METRIC)
+    client: MetricClientService = build_client(ServiceType.METRICS)
     results = client.list_metrics(job_id=job_id)
-    metric_list_table.render(results)
+    metrics_list_table.render(results)
 
 
-@metric_app.command("show")
-def show_metric(
+@metrics_app.command("show")
+def show_metrics(
     job_id: int = typer.Argument(..., help="ID of job"),
-    metric_name: List[str] = typer.Option(..., help="metric name"),
+    name: List[str] = typer.Option(..., help="metrics name"),
 ):
     """Create a job configuration YAML file"""
-    client: MetricClientService = build_client(ServiceType.METRIC)
-    for metric in metric_name:
-        results = client.get_metric_values(job_id, metric)
-        metric_table.render(results)
+    client: MetricClientService = build_client(ServiceType.METRICS)
+    for metrics in name:
+        results = client.get_metric_values(job_id, metrics)
+        metrics_table.render(results)

--- a/pfcli/job.py
+++ b/pfcli/job.py
@@ -152,7 +152,7 @@ artifact_table = TableFormatter(
     headers=["ID", "Name", "Path", "Mtime", "Media Type"],
 )
 metric_list_table = TableFormatter(
-    name="Metrics",
+    name="Metric List",
     fields=["name"],
     headers=["Name"],
 )
@@ -630,12 +630,14 @@ def metric_list(
     results = client.list_metrics(job_id=job_id)
     metric_list_table.render(results)
 
+
 @metric_app.command("show")
 def show_metric(
     job_id: int = typer.Argument(..., help="ID of job"),
-    metric_name: str = typer.Argument(..., help="metric name"),
+    metric_name: List[str] = typer.Option(..., help="metric name"),
 ):
     """Create a job configuration YAML file"""
     client: MetricClientService = build_client(ServiceType.METRIC)
-    results = client.get_metric_values(job_id, metric_name)
-    metric_table.render(results)
+    for metric in metric_name:
+        results = client.get_metric_values(job_id, metric)
+        metric_table.render(results)

--- a/pfcli/job.py
+++ b/pfcli/job.py
@@ -4,43 +4,43 @@
 
 import asyncio
 import re
-from pathlib import Path
-from typing import Dict, Generator, Optional, List, Tuple
-from dateutil import parser
-from dateutil.parser import parse
 from datetime import datetime
+from pathlib import Path
+from typing import Dict, Generator, List, Optional, Tuple
 
+import ruamel.yaml
 import tabulate
-from pfcli.service.client.metrics import MetricsClientService
 import typer
 import yaml
-import ruamel.yaml
 from click import Choice
+from dateutil import parser
+from dateutil.parser import parse
 
 from pfcli.service import JobType, ServiceType, storage_type_map_inv
 from pfcli.service.client import (
-    ProjectDataClientService,
-    ProjectExperimentClientService,
-    ProjectJobClientService,
     GroupVMConfigClientService,
     JobArtifactClientService,
     JobCheckpointClientService,
     JobClientService,
     JobTemplateClientService,
     JobWebSocketClientService,
+    ProjectDataClientService,
+    ProjectExperimentClientService,
+    ProjectJobClientService,
     build_client,
 )
+from pfcli.service.client.metrics import MetricsClientService
 from pfcli.service.client.project import ProjectClientService
 from pfcli.service.config import build_job_configurator
 from pfcli.service.formatter import PanelFormatter, TableFormatter
 from pfcli.utils import (
+    datetime_to_pretty_str,
+    datetime_to_simple_string,
     get_default_editor,
     open_editor,
     secho_error_and_exit,
-    datetime_to_pretty_str,
     timedelta_to_pretty_str,
     utc_to_local,
-    datetime_to_simple_string,
 )
 
 tabulate.PRESERVE_WHITESPACE = True
@@ -638,6 +638,6 @@ def show_metrics(
 ):
     """Show metrics values"""
     client: MetricsClientService = build_client(ServiceType.METRICS)
-    for metrics in name:
-        results = client.get_metrics_values(job_id, metrics)
-        metrics_table.render(results)
+    for metric_name in name:
+        metrics = client.get_metrics_values(job_id, metric_name)
+        metrics_table.render(metrics)

--- a/pfcli/job.py
+++ b/pfcli/job.py
@@ -625,8 +625,8 @@ def log(
 def metrics_list(
     job_id: int = typer.Argument(..., help="ID of job"),
 ):
-    """Show all available metric names"""
-    client: MetricClientService = build_client(ServiceType.METRICS)
+    """Show available metrics"""
+    client: MetricsClientService = build_client(ServiceType.METRICS)
     results = client.list_metrics(job_id=job_id)
     metrics_list_table.render(results)
 
@@ -636,8 +636,8 @@ def show_metrics(
     job_id: int = typer.Argument(..., help="ID of job"),
     name: List[str] = typer.Option(..., help="metrics name"),
 ):
-    """Create a job configuration YAML file"""
-    client: MetricClientService = build_client(ServiceType.METRICS)
+    """Show metrics values"""
+    client: MetricsClientService = build_client(ServiceType.METRICS)
     for metrics in name:
-        results = client.get_metric_values(job_id, metrics)
+        results = client.get_metrics_values(job_id, metrics)
         metrics_table.render(results)

--- a/pfcli/service/__init__.py
+++ b/pfcli/service/__init__.py
@@ -33,6 +33,7 @@ class ServiceType(str, Enum):
     JOB_WS = "JOB_WS"
     SERVE = "SERVE"
     BILLING_SUMMARY = "BILLING_SUMMARY"
+    METRIC = "METRIC"
 
 
 class GroupRole(str, Enum):

--- a/pfcli/service/__init__.py
+++ b/pfcli/service/__init__.py
@@ -33,7 +33,7 @@ class ServiceType(str, Enum):
     JOB_WS = "JOB_WS"
     SERVE = "SERVE"
     BILLING_SUMMARY = "BILLING_SUMMARY"
-    METRIC = "METRIC"
+    METRICS = "METRICS"
 
 
 class GroupRole(str, Enum):

--- a/pfcli/service/client/__init__.py
+++ b/pfcli/service/client/__init__.py
@@ -7,7 +7,7 @@ from pfcli.service import ServiceType
 from pfcli.service.client.base import ClientService
 from pfcli.service.client.billing import BillingClientService
 from pfcli.service.client.checkpoint import CheckpointClientService
-from pfcli.service.client.metric import MetricClientService
+from pfcli.service.client.metrics import MetricsClientService
 from pfcli.service.client.credential import (
     CredentialClientService,
     CredentialTypeClientService,
@@ -140,8 +140,8 @@ client_template_map: Dict[ServiceType, Tuple[Type[ClientService], Template]] = {
         BillingClientService,
         Template(get_meter_uri("training/instances/price/")),
     ),
-    ServiceType.METRIC: (
-        MetricClientService,
+    ServiceType.METRICS: (
+        MetricsClientService,
         Template(get_observatory_uri("graphql")),
     ),
 }

--- a/pfcli/service/client/__init__.py
+++ b/pfcli/service/client/__init__.py
@@ -7,7 +7,6 @@ from pfcli.service import ServiceType
 from pfcli.service.client.base import ClientService
 from pfcli.service.client.billing import BillingClientService
 from pfcli.service.client.checkpoint import CheckpointClientService
-from pfcli.service.client.metrics import MetricsClientService
 from pfcli.service.client.credential import (
     CredentialClientService,
     CredentialTypeClientService,
@@ -27,6 +26,7 @@ from pfcli.service.client.job import (
     JobTemplateClientService,
     JobWebSocketClientService,
 )
+from pfcli.service.client.metrics import MetricsClientService
 from pfcli.service.client.project import (
     ProjectClientService,
     ProjectCredentialClientService,
@@ -48,10 +48,10 @@ from pfcli.utils import (
     get_auth_uri,
     get_meter_uri,
     get_mr_uri,
+    get_observatory_uri,
     get_pfs_uri,
     get_uri,
     get_wss_uri,
-    get_observatory_uri,
 )
 
 client_template_map: Dict[ServiceType, Tuple[Type[ClientService], Template]] = {

--- a/pfcli/service/client/__init__.py
+++ b/pfcli/service/client/__init__.py
@@ -7,6 +7,7 @@ from pfcli.service import ServiceType
 from pfcli.service.client.base import ClientService
 from pfcli.service.client.billing import BillingClientService
 from pfcli.service.client.checkpoint import CheckpointClientService
+from pfcli.service.client.metric import MetricClientService
 from pfcli.service.client.credential import (
     CredentialClientService,
     CredentialTypeClientService,
@@ -50,6 +51,7 @@ from pfcli.utils import (
     get_pfs_uri,
     get_uri,
     get_wss_uri,
+    get_observatory_uri,
 )
 
 client_template_map: Dict[ServiceType, Tuple[Type[ClientService], Template]] = {
@@ -137,6 +139,10 @@ client_template_map: Dict[ServiceType, Tuple[Type[ClientService], Template]] = {
     ServiceType.BILLING_SUMMARY: (
         BillingClientService,
         Template(get_meter_uri("training/instances/price/")),
+    ),
+    ServiceType.METRIC: (
+        MetricClientService,
+        Template(get_observatory_uri("graphql")),
     ),
 }
 

--- a/pfcli/service/client/base.py
+++ b/pfcli/service/client/base.py
@@ -96,48 +96,42 @@ class ClientService:
     def list(self, path: Optional[str] = None, **kwargs) -> Response:
         return requests.get(
             self.url_template.render(path=path, **self.url_kwargs),
-            headers=get_auth_header(),
-            **kwargs,
+            **{"headers": get_auth_header(), **kwargs},
         )
 
     @auto_token_refresh
     def retrieve(self, pk: T, path: Optional[str] = None, **kwargs) -> Response:
         return requests.get(
             self.url_template.render(pk=pk, path=path, **self.url_kwargs),
-            headers=get_auth_header(),
-            **kwargs,
+            **{"headers": get_auth_header(), **kwargs},
         )
 
     @auto_token_refresh
     def post(self, path: Optional[str] = None, **kwargs) -> Response:
         return requests.post(
             self.url_template.render(path=path, **self.url_kwargs),
-            headers=get_auth_header(),
-            **kwargs,
+            **{"headers": get_auth_header(), **kwargs},
         )
 
     @auto_token_refresh
     def partial_update(self, pk: T, path: Optional[str] = None, **kwargs) -> Response:
         return requests.patch(
             self.url_template.render(pk=pk, path=path, **self.url_kwargs),
-            headers=get_auth_header(),
-            **kwargs,
+            **{"headers": get_auth_header(), **kwargs},
         )
 
     @auto_token_refresh
     def delete(self, pk: T, path: Optional[str] = None, **kwargs) -> Response:
         return requests.delete(
             self.url_template.render(pk=pk, path=path, **self.url_kwargs),
-            headers=get_auth_header(),
-            **kwargs,
+            **{"headers": get_auth_header(), **kwargs},
         )
 
     @auto_token_refresh
     def update(self, pk: T, path: Optional[str] = None, **kwargs) -> Response:
         return requests.put(
             self.url_template.render(pk=pk, path=path, **self.url_kwargs),
-            headers=get_auth_header(),
-            **kwargs,
+            **{"headers": get_auth_header(), **kwargs},
         )
 
     def bare_post(self, path: Optional[str] = None, **kwargs) -> Response:

--- a/pfcli/service/client/metric.py
+++ b/pfcli/service/client/metric.py
@@ -1,36 +1,32 @@
 # Copyright (C) 2022 FriendliAI
 
+"""PeriFlow MetricClient Service"""
+
 import json
-import requests
-from requests.models import Response
 from typing import List
 
 from pfcli.service.client.base import ClientService, safe_request
-from pfcli.service.auth import auto_token_refresh, get_auth_header
+
 
 class MetricClientService(ClientService):
-
-    @auto_token_refresh
-    def _post(self, **kwargs) -> Response:
-        return requests.post(
-            self.url_template.render(**self.url_kwargs),
-            **kwargs,
-        )
+    """PeriFlow MetricClientService class"""
 
     def list_metrics(
         self,
         job_id: int,
     ) -> List[str]:
         """Show available metric names."""
-        fields = f"task: \"{job_id}\", telemetry: null, start: null, until: null"
+        fields = f'task: "{job_id}", telemetry: null, start: null, until: null'
         query = "{ sampleQuery(fields: {" + fields + "}) {name} }"
-        resp = safe_request(self._post, err_prefix=f"Failed to get metrics of ({job_id}).")(
-            headers={**get_auth_header(), "Content-Type": "application/json"},
+        resp = safe_request(
+            self.post, err_prefix=f"Failed to get metrics of ({job_id})."
+        )(
+            headers={"Content-Type": "application/json"},
             data=json.dumps({"query": query}),
         )
-        data = resp.json()["data"]
-        names = set(sample.get("name", None) for sample in data["sampleQuery"])
-        return [{"name": name} for name in names]
+        data = resp.json()["data"]["sampleQuery"]
+        names = set(sample.get("name", None) for sample in data)
+        return [{"name": name} for name in names if name]
 
     def get_metric_values(
         self,
@@ -38,25 +34,22 @@ class MetricClientService(ClientService):
         metric_name: str,
         limit: int = 10,
     ) -> dict[str, str]:
-        fields = f"task: \"{job_id}\", telemetry: \"{metric_name}\", limit: {limit}, goal: LAST"
+        fields = (
+            f'task: "{job_id}", telemetry: "{metric_name}", limit: {limit}, goal: LAST'
+        )
         query = "{ representativeSamples(fields: {" + fields + "}) {created, value} }"
-        resp = safe_request(self._post, err_prefix=f"Failed to get metrics of ({job_id}).")(
-            headers={**get_auth_header(), "Content-Type": "application/json"},
+        resp = safe_request(
+            self.post, err_prefix=f"Failed to get metrics of ({job_id})."
+        )(
+            headers={"Content-Type": "application/json"},
             data=json.dumps({"query": query}),
         )
-        data = resp.json()["data"]
+        samples = resp.json()["data"]["representativeSamples"]
 
         metrics = []
-        for sample in data["representativeSamples"]:
+        for sample in samples:
             created = sample.get("created", None)
             value_json = sample.get("value", None)
             value = json.loads(value_json).get("data", None)
-            metrics.append(
-                {
-                    "name": metric_name,
-                    "created": created,
-                    "value": value
-                }
-            )
+            metrics.append({"name": metric_name, "created": created, "value": value})
         return metrics
-

--- a/pfcli/service/client/metric.py
+++ b/pfcli/service/client/metric.py
@@ -1,0 +1,62 @@
+# Copyright (C) 2022 FriendliAI
+
+import json
+import requests
+from requests.models import Response
+from typing import List
+
+from pfcli.service.client.base import ClientService, safe_request
+from pfcli.service.auth import auto_token_refresh, get_auth_header
+
+class MetricClientService(ClientService):
+
+    @auto_token_refresh
+    def _post(self, **kwargs) -> Response:
+        return requests.post(
+            self.url_template.render(**self.url_kwargs),
+            **kwargs,
+        )
+
+    def list_metrics(
+        self,
+        job_id: int,
+    ) -> List[str]:
+        """Show available metric names."""
+        fields = f"task: \"{job_id}\", telemetry: null, start: null, until: null"
+        query = "{ sampleQuery(fields: {" + fields + "}) {name} }"
+        resp = safe_request(self._post, err_prefix=f"Failed to get metrics of ({job_id}).")(
+            headers={**get_auth_header(), "Content-Type": "application/json"},
+            data=json.dumps({"query": query}),
+        )
+        data = resp.json()["data"]
+        names = set(sample.get("name", None) for sample in data["sampleQuery"])
+        return [{"name": name} for name in names]
+
+    def get_metric_values(
+        self,
+        job_id: int,
+        metric_name: str,
+        limit: int = 10,
+    ) -> dict[str, str]:
+        fields = f"task: \"{job_id}\", telemetry: \"{metric_name}\", limit: {limit}, goal: LAST"
+        query = "{ representativeSamples(fields: {" + fields + "}) {created, value} }"
+        resp = safe_request(self._post, err_prefix=f"Failed to get metrics of ({job_id}).")(
+            headers={**get_auth_header(), "Content-Type": "application/json"},
+            data=json.dumps({"query": query}),
+        )
+        data = resp.json()["data"]
+
+        metrics = []
+        for sample in data["representativeSamples"]:
+            created = sample.get("created", None)
+            value_json = sample.get("value", None)
+            value = json.loads(value_json).get("data", None)
+            metrics.append(
+                {
+                    "name": metric_name,
+                    "created": created,
+                    "value": value
+                }
+            )
+        return metrics
+

--- a/pfcli/service/client/metrics.py
+++ b/pfcli/service/client/metrics.py
@@ -1,6 +1,6 @@
 # Copyright (C) 2022 FriendliAI
 
-"""PeriFlow MetricClient Service"""
+"""PeriFlow MetricsClient Service"""
 
 import json
 from typing import List
@@ -8,14 +8,14 @@ from typing import List
 from pfcli.service.client.base import ClientService, safe_request
 
 
-class MetricClientService(ClientService):
-    """PeriFlow MetricClientService class"""
+class MetricsClientService(ClientService):
+    """PeriFlow MetricsClientService class"""
 
     def list_metrics(
         self,
         job_id: int,
     ) -> List[str]:
-        """Show available metric names."""
+        """Show available metrics."""
         fields = f'task: "{job_id}", telemetry: null, start: null, until: null'
         query = "{ sampleQuery(fields: {" + fields + "}) {name} }"
         resp = safe_request(
@@ -28,14 +28,14 @@ class MetricClientService(ClientService):
         names = set(sample.get("name", None) for sample in data)
         return [{"name": name} for name in names if name]
 
-    def get_metric_values(
+    def get_metrics_values(
         self,
         job_id: int,
-        metric_name: str,
+        name: str,
         limit: int = 10,
     ) -> dict[str, str]:
         fields = (
-            f'task: "{job_id}", telemetry: "{metric_name}", limit: {limit}, goal: LAST'
+            f'task: "{job_id}", telemetry: "{name}", limit: {limit}, goal: LAST'
         )
         query = "{ representativeSamples(fields: {" + fields + "}) {created, value} }"
         resp = safe_request(
@@ -51,5 +51,5 @@ class MetricClientService(ClientService):
             created = sample.get("created", None)
             value_json = sample.get("value", None)
             value = json.loads(value_json).get("data", None)
-            metrics.append({"name": metric_name, "created": created, "value": value})
+            metrics.append({"name": name, "created": created, "value": value})
         return metrics

--- a/pfcli/service/client/metrics.py
+++ b/pfcli/service/client/metrics.py
@@ -3,9 +3,11 @@
 """PeriFlow MetricsClient Service"""
 
 import json
-from typing import List
+from typing import List, TypeVar
 
 from pfcli.service.client.base import ClientService, safe_request
+
+MetricsType = TypeVar("MetricsType")
 
 
 class MetricsClientService(ClientService):
@@ -14,7 +16,7 @@ class MetricsClientService(ClientService):
     def list_metrics(
         self,
         job_id: int,
-    ) -> List[str]:
+    ) -> List[dict[str, str]]:
         """Show available metrics."""
         fields = f'task: "{job_id}", telemetry: null, start: null, until: null'
         query = "{ sampleQuery(fields: {" + fields + "}) {name} }"
@@ -33,10 +35,8 @@ class MetricsClientService(ClientService):
         job_id: int,
         name: str,
         limit: int = 10,
-    ) -> dict[str, str]:
-        fields = (
-            f'task: "{job_id}", telemetry: "{name}", limit: {limit}, goal: LAST'
-        )
+    ) -> List[dict[str, MetricsType]]:
+        fields = f'task: "{job_id}", telemetry: "{name}", limit: {limit}, goal: LAST'
         query = "{ representativeSamples(fields: {" + fields + "}) {created, value} }"
         resp = safe_request(
             self.post, err_prefix=f"Failed to get metrics of ({job_id})."

--- a/pfcli/utils.py
+++ b/pfcli/utils.py
@@ -25,13 +25,14 @@ from pfcli.service import CloudType, StorageType, storage_region_map, cloud_regi
 
 # Variables
 periflow_directory = Path.home() / ".periflow"
-periflow_api_server = "https://api-staging.friendli.ai/api/"
-periflow_ws_server = "wss://api-ws-staging.friendli.ai/ws/"
-periflow_discuss_url = "https://discuss-staging.friendli.ai/"
-periflow_mr_server = "https://pfmodelregistry-staging.friendli.ai/"
+periflow_api_server = "https://api-dev.friendli.ai/api/"
+periflow_ws_server = "wss://api-ws-dev.friendli.ai/ws/"
+periflow_discuss_url = "https://discuss-dev.friendli.ai/"
+periflow_mr_server = "https://pfmodelregistry-dev.friendli.ai/"
 periflow_serve_server = "http://0.0.0.0:8000/"
-periflow_auth_server = "https://pfauth-staging.friendli.ai/"
-periflow_meter_server = "https://pfmeter-staging.friendli.ai/"
+periflow_auth_server = "https://pfauth-dev.friendli.ai/"
+periflow_meter_server = "https://pfmeter-dev.friendli.ai/"
+periflow_observatory_server = "https://pfo-dev.friendli.ai/"
 
 
 def get_periflow_directory() -> Path:
@@ -110,6 +111,10 @@ def get_mr_uri(path: str) -> str:
 
 def get_meter_uri(path: str) -> str:
     return urljoin(periflow_meter_server, path)
+
+
+def get_observatory_uri(path: str) -> str:
+    return urljoin(periflow_observatory_server, path)
 
 
 def secho_error_and_exit(text: str, color: str = typer.colors.RED):

--- a/pfcli/utils.py
+++ b/pfcli/utils.py
@@ -25,14 +25,14 @@ from pfcli.service import CloudType, StorageType, storage_region_map, cloud_regi
 
 # Variables
 periflow_directory = Path.home() / ".periflow"
-periflow_api_server = "https://api-dev.friendli.ai/api/"
-periflow_ws_server = "wss://api-ws-dev.friendli.ai/ws/"
-periflow_discuss_url = "https://discuss-dev.friendli.ai/"
-periflow_mr_server = "https://pfmodelregistry-dev.friendli.ai/"
+periflow_api_server = "https://api-staging.friendli.ai/api/"
+periflow_ws_server = "wss://api-ws-staging.friendli.ai/ws/"
+periflow_discuss_url = "https://discuss-staging.friendli.ai/"
+periflow_mr_server = "https://pfmodelregistry-staging.friendli.ai/"
 periflow_serve_server = "http://0.0.0.0:8000/"
-periflow_auth_server = "https://pfauth-dev.friendli.ai/"
-periflow_meter_server = "https://pfmeter-dev.friendli.ai/"
-periflow_observatory_server = "https://pfo-dev.friendli.ai/"
+periflow_auth_server = "https://pfauth-staging.friendli.ai/"
+periflow_meter_server = "https://pfmeter-staging.friendli.ai/"
+periflow_observatory_server = "https://pfo-staging.friendli.ai/"
 
 
 def get_periflow_directory() -> Path:


### PR DESCRIPTION
This PR adds `job metrics` commands: `metrics list` and `metrics show`

### Example
The following is an example of using job metrics commands:

```bash
> pf job metrics list <JOB_ID>
        Metrics List
┏━━━━━━━━━━━━━━━━━━━━━━━━━━┓
┃ Name                     ┃
┡━━━━━━━━━━━━━━━━━━━━━━━━━━┩
│ train_loss               │
└──────────────────────────┘
```

```bash
# NOTE that you can pass multiple metrics names.
> pf job metrics show <JOB_ID> --name <METRICS_NAME_1>
                               Metrics
┏━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━┓
┃ Name       ┃ Created                          ┃ Value             ┃
┡━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━┩
│ train_loss │ 2022-09-24T14:27:19.748559+00:00 │ 7.088735595703125 │
└────────────┴──────────────────────────────────┴───────────────────┘
```
### Minor Changes
To pass additional header keywords I have made modifications in `client.base`.
Please have a look and let me know if there is any issue.