### PR TITLE
Rollback to old version typing to support old Python versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Please visit [docs.periflow.ai](https://docs.periflow.ai) for the detailed guide
 
 ## Installation
 
-You can simply install the package using `pip`.
+You can simply install the package using `pip`. Python version >= 3.8 is required.
 
 ```sh
 pip install periflow-cli

--- a/pfcli/checkpoint.py
+++ b/pfcli/checkpoint.py
@@ -97,8 +97,9 @@ model_info_panel = PanelFormatter(
         "#Layers",
         "Max Length",
         "Vocab Size",
-    ]
+    ],
 )
+
 
 @app.command()
 def list(

--- a/pfcli/deployment.py
+++ b/pfcli/deployment.py
@@ -3,7 +3,7 @@
 """CLI for Deployment"""
 
 from dateutil.parser import parse
-from typing import Optional
+from typing import Any, Dict, Optional
 
 import ruamel.yaml
 import typer
@@ -231,8 +231,12 @@ def metrics(
     )
     metrics["id"] = metrics["deployment_id"]
     # ns => ms
-    metrics["latency"] = "{:.3f}".format(metrics["latency"] / 1000000) if "latency" in metrics else None
-    metrics["throughput"] = "{:.3f}".format(metrics["throughput"]) if "throughput" in metrics else None
+    metrics["latency"] = (
+        "{:.3f}".format(metrics["latency"] / 1000000) if "latency" in metrics else None
+    )
+    metrics["throughput"] = (
+        "{:.3f}".format(metrics["throughput"]) if "throughput" in metrics else None
+    )
     deployment_metrics_table.render([metrics])
 
 
@@ -243,10 +247,15 @@ def usage():
     usages = client.get_deployment_usage()
 
     deployments = [
-        {"id": id, "type": info["deployment_type"] , "duration": datetime.timedelta(seconds=int(info["duration"]))}
+        {
+            "id": id,
+            "type": info["deployment_type"],
+            "duration": datetime.timedelta(seconds=int(info["duration"])),
+        }
         for id, info in usages.items()
     ]
     deployment_usage_table.render(deployments)
+
 
 @app.command()
 def create(
@@ -287,7 +296,7 @@ def create(
         secho_error_and_exit("Checkpoint ID should be in UUID format.")
 
     try:
-        config: dict = yaml.safe_load(config_file)
+        config: Dict[str, Any] = yaml.safe_load(config_file)
     except yaml.YAMLError as e:
         secho_error_and_exit(f"Error occurred while parsing engine config file... {e}")
 

--- a/pfcli/group.py
+++ b/pfcli/group.py
@@ -3,6 +3,7 @@
 """PeriFlow Group (Organization) CLI"""
 
 from uuid import UUID
+from typing import Any, Dict
 
 import typer
 
@@ -94,7 +95,7 @@ def _get_org_user_id_by_name(org_id: UUID, username: str) -> UUID:
     secho_error_and_exit(f"{username} is not a member of this organization.")
 
 
-def get_current_org() -> dict:
+def get_current_org() -> Dict[str, Any]:
     user_group_client: UserGroupClientService = build_client(ServiceType.USER_GROUP)
 
     curr_org_id = get_current_group_id()

--- a/pfcli/job.py
+++ b/pfcli/job.py
@@ -6,7 +6,7 @@ import asyncio
 import re
 from datetime import datetime
 from pathlib import Path
-from typing import Generator, List, Optional, Tuple
+from typing import Any, Dict, Generator, List, Optional, Tuple
 from uuid import UUID
 
 import ruamel.yaml
@@ -176,7 +176,7 @@ metrics_table = TableFormatter(
 
 
 def refine_config(
-    config: dict,
+    config: Dict[str, Any],
     vm_name: Optional[str],
     num_devices: Optional[int],
     job_name: Optional[str],
@@ -265,7 +265,7 @@ def run(
 ):
     """Run a job."""
     try:
-        config: dict = yaml.safe_load(config_file)
+        config: Dict[str, Any] = yaml.safe_load(config_file)
     except yaml.YAMLError as e:
         secho_error_and_exit(f"Error occurred while parsing config file... {e}")
 
@@ -512,7 +512,10 @@ def _split_machine_ids(value: Optional[str]) -> Optional[List[int]]:
 
 
 def _format_log_string(
-    log_record: dict, show_time: bool, show_machine_id: bool, use_style: bool = True
+    log_record: Dict[str, Any],
+    show_time: bool,
+    show_machine_id: bool,
+    use_style: bool = True,
 ) -> Generator[Tuple[str, bool], None, None]:
     timestamp_str = f"⏰ {datetime_to_simple_string(utc_to_local(parser.parse(log_record['timestamp'])))} "
     node_rank = log_record["node_rank"]

--- a/pfcli/service/auth.py
+++ b/pfcli/service/auth.py
@@ -4,7 +4,7 @@
 
 import functools
 from enum import Enum
-from typing import Callable, Union
+from typing import Any, Callable, Dict, Union
 
 import requests
 
@@ -31,7 +31,7 @@ token_path_map = {
 }
 
 
-def get_auth_header() -> dict:
+def get_auth_header() -> Dict[str, Any]:
     return {"Authorization": f"Bearer {get_token(TokenType.ACCESS)}"}
 
 

--- a/pfcli/service/client/base.py
+++ b/pfcli/service/client/base.py
@@ -9,7 +9,7 @@ from dataclasses import dataclass
 from functools import wraps
 from requests.models import Response
 from string import Template
-from typing import Callable, Generic, Optional, TypeVar, Union
+from typing import Any, Callable, Dict, Generic, Optional, TypeVar, Union
 from urllib.parse import urljoin, urlparse
 
 import uuid
@@ -150,7 +150,7 @@ class UserRequestMixin:
     def _userinfo(self) -> Response:
         return requests.get(get_auth_uri("oauth2/userinfo"), headers=get_auth_header())
 
-    def get_current_userinfo(self) -> dict:
+    def get_current_userinfo(self) -> Dict[str, Any]:
         response = safe_request(self._userinfo, err_prefix="Failed to get userinfo.")()
         return response.json()
 

--- a/pfcli/service/client/billing.py
+++ b/pfcli/service/client/billing.py
@@ -2,7 +2,7 @@
 
 from enum import Enum
 from string import Template
-from typing import List, Optional
+from typing import Any, Dict, List, Optional
 
 from pfcli.service.client.base import (
     ClientService,
@@ -34,7 +34,7 @@ class PFTBillingClientService(
         end_date: str,
         agg_by: str = "user_id",
         time_granularity: Optional[TimeGranularity] = None,
-    ) -> List[dict]:
+    ) -> List[Dict[str, Any]]:
         params = {
             "organization_id": str(self.group_id),
             "project_id": str(self.project_id),

--- a/pfcli/service/client/checkpoint.py
+++ b/pfcli/service/client/checkpoint.py
@@ -2,7 +2,7 @@
 
 """PeriFlow CheckpointClient Service"""
 
-from typing import List, Optional
+from typing import Any, Dict, List, Optional
 from uuid import UUID
 
 import requests
@@ -14,7 +14,7 @@ from pfcli.service.client.base import ClientService, safe_request
 
 
 class CheckpointClientService(ClientService[UUID]):
-    def get_checkpoint(self, checkpoint_id: UUID) -> dict:
+    def get_checkpoint(self, checkpoint_id: UUID) -> Dict[str, Any]:
         response = safe_request(
             self.retrieve, err_prefix="Failed to get info of checkpoint"
         )(pk=checkpoint_id)
@@ -29,11 +29,11 @@ class CheckpointClientService(ClientService[UUID]):
         credential_id: Optional[str] = None,
         iteration: Optional[int] = None,
         storage_name: Optional[str] = None,
-        files: Optional[List[dict]] = None,
-        dist_config: Optional[dict] = None,
-        data_config: Optional[dict] = None,
-        job_setting_config: Optional[dict] = None
-    ) -> dict:
+        files: Optional[List[Dict[str, Any]]] = None,
+        dist_config: Optional[Dict[str, Any]] = None,
+        data_config: Optional[Dict[str, Any]] = None,
+        job_setting_config: Optional[Dict[str, Any]] = None
+    ) -> Dict[str, Any]:
         request_data = {}
         if vendor is not None:
             request_data["vendor"] = vendor
@@ -79,7 +79,7 @@ class CheckpointClientService(ClientService[UUID]):
             headers=get_auth_header(),
         )
 
-    def get_checkpoint_download_urls(self, checkpoint_id: UUID) -> List[dict]:
+    def get_checkpoint_download_urls(self, checkpoint_id: UUID) -> List[Dict[str, Any]]:
         response = safe_request(
             self.download, err_prefix="Failed to get download URLs of checkpoint files."
         )(checkpoint_id=checkpoint_id)

--- a/pfcli/service/client/credential.py
+++ b/pfcli/service/client/credential.py
@@ -3,7 +3,7 @@
 """PeriFlow CredentialClient Service"""
 
 
-from typing import Optional
+from typing import Any, Dict, Optional
 from uuid import UUID
 
 from pfcli.service import CredType, cred_type_map
@@ -11,7 +11,7 @@ from pfcli.service.client.base import ClientService, safe_request
 
 
 class CredentialClientService(ClientService[UUID]):
-    def get_credential(self, credential_id: UUID) -> dict:
+    def get_credential(self, credential_id: UUID) -> Dict[str, Any]:
         response = safe_request(self.retrieve, err_prefix="Credential is not found.")(
             pk=credential_id
         )
@@ -23,8 +23,8 @@ class CredentialClientService(ClientService[UUID]):
         *,
         name: Optional[str] = None,
         type_version: Optional[str] = None,
-        value: Optional[dict] = None
-    ) -> dict:
+        value: Optional[Dict[str, Any]] = None
+    ) -> Dict[str, Any]:
         request_data = {}
         if name is not None:
             request_data["name"] = name
@@ -44,7 +44,7 @@ class CredentialClientService(ClientService[UUID]):
 
 
 class CredentialTypeClientService(ClientService):
-    def get_schema_by_type(self, cred_type: CredType) -> Optional[dict]:
+    def get_schema_by_type(self, cred_type: CredType) -> Optional[Dict[str, Any]]:
         type_name = cred_type_map[cred_type]
         response = safe_request(
             self.list, err_prefix="Failed to get credential schema."

--- a/pfcli/service/client/data.py
+++ b/pfcli/service/client/data.py
@@ -8,7 +8,7 @@ from concurrent.futures import ThreadPoolExecutor, wait, FIRST_EXCEPTION
 from enum import Enum
 from functools import wraps
 from pathlib import Path
-from typing import Dict, List, Optional
+from typing import Any, Dict, List, Optional
 
 import typer
 from requests import Request, Session
@@ -28,7 +28,7 @@ S3_UPLOAD_SIZE_LIMIT = 5 * 1024 * 1024 * 1024  # 5 GiB
 
 
 class DataClientService(ClientService):
-    def get_dataset(self, dataset_id: int) -> dict:
+    def get_dataset(self, dataset_id: int) -> Dict[str, Any]:
         response = safe_request(
             self.retrieve, err_prefix=f"Dataset ({dataset_id}) is not found."
         )(pk=dataset_id)
@@ -43,10 +43,10 @@ class DataClientService(ClientService):
         region: Optional[str] = None,
         storage_name: Optional[str] = None,
         credential_id: Optional[str] = None,
-        metadata: Optional[dict] = None,
-        files: Optional[List[dict]] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+        files: Optional[List[Dict[str, Any]]] = None,
         active: Optional[bool] = None,
-    ) -> dict:
+    ) -> Dict[str, Any]:
         # Valdiate region
         if vendor is not None or region is not None:
             prev_info = self.get_dataset(dataset_id)
@@ -80,7 +80,7 @@ class DataClientService(ClientService):
     def delete_dataset(self, dataset_id: int) -> None:
         safe_request(self.delete, err_prefix="Failed to delete dataset")(pk=dataset_id)
 
-    def get_spu_urls(self, dataset_id: int, paths: List[str]) -> List[dict]:
+    def get_spu_urls(self, dataset_id: int, paths: List[str]) -> List[Dict[str, Any]]:
         """Get single part upload URLs for multiple files.
 
         Args:
@@ -88,7 +88,7 @@ class DataClientService(ClientService):
             paths (List[str]): _description_
 
         Returns:
-            List[dict]: _description_
+            List[Dict[str, Any]]: _description_
         """
         response = safe_request(self.post, err_prefix="Failed to get presigned URLs.")(
             path=f"{dataset_id}/upload/", json={"paths": paths}
@@ -97,7 +97,7 @@ class DataClientService(ClientService):
 
     def get_mpu_urls(
         self, dataset_id: int, paths: List[str], src_path: Optional[str] = None
-    ) -> List[dict]:
+    ) -> List[Dict[str, Any]]:
         """Get multipart upload URLs for multiple datasets
 
         Args:
@@ -105,7 +105,7 @@ class DataClientService(ClientService):
             paths (List[str]): A list of upload target paths
 
         Returns:
-            List[dict]: A list of multipart upload responses for multiple target files.
+            List[Dict[str, Any]]: A list of multipart upload responses for multiple target files.
             {
                 "path": "string",
                 "upload_id": "string",
@@ -139,7 +139,7 @@ class DataClientService(ClientService):
         return start_mpu_resps
 
     def complete_mpu(
-        self, dataset_id: int, path: str, upload_id: str, parts: List[dict]
+        self, dataset_id: int, path: str, upload_id: str, parts: List[Dict[str, Any]]
     ) -> None:
         safe_request(
             self.post, err_prefix=f"Failed to complete multipart upload for {path}"
@@ -164,7 +164,7 @@ class DataClientService(ClientService):
         )
 
     def _multipart_upload_file(
-        self, dataset_id: int, file_path: str, url_dict: dict, ctx: tqdm
+        self, dataset_id: int, file_path: str, url_dict: Dict[str, Any], ctx: tqdm
     ) -> None:
         # TODO (ym): parallelize each part upload.
         parts = []
@@ -208,7 +208,7 @@ class DataClientService(ClientService):
         self,
         dataset_id: int,
         spu_url_dicts: List[Dict[str, str]],
-        mpu_url_dicts: List[dict],
+        mpu_url_dicts: List[Dict[str, Any]],
         source_path: Path,
         expand: bool,
     ) -> None:

--- a/pfcli/service/client/deployment.py
+++ b/pfcli/service/client/deployment.py
@@ -2,27 +2,27 @@
 
 """PeriFlow DeploymentClient Service"""
 
-from typing import List
+from typing import Any, Dict
 from string import Template
 
 from pfcli.service.client.base import ClientService, safe_request, ProjectRequestMixin
- 
+
 
 class DeploymentClientService(ClientService[str]):
-    def get_deployment(self, deployment_id: str) -> dict:
+    def get_deployment(self, deployment_id: str) -> Dict[str, Any]:
         response = safe_request(
             self.retrieve,
             err_prefix=f"Deployment ({deployment_id}) is not found. You may enter wrongID.",
         )(pk=deployment_id)
         return response.json()
 
-    def create_deployment(self, config: dict) -> dict:
+    def create_deployment(self, config: Dict[str, Any]) -> Dict[str, Any]:
         response = safe_request(self.post, err_prefix="Failed to post new deployment.")(
             json=config
         )
         return response.json()
 
-    def list_deployments(self, project_id: str) -> dict:
+    def list_deployments(self, project_id: str) -> Dict[str, Any]:
         response = safe_request(self.list, err_prefix="Failed to list deployments.")(
             params={"project_id": project_id}
         )
@@ -33,20 +33,22 @@ class DeploymentClientService(ClientService[str]):
             pk=deployment_id
         )
 
+
 class DeploymentMetricsClientService(ClientService):
-    def get_metrics(self, deployment_id: str, time_window: int) -> dict:
+    def get_metrics(self, deployment_id: str, time_window: int) -> Dict[str, Any]:
         response = safe_request(
             self.list,
             err_prefix=f"Deployment ({deployment_id}) is not found. You may enter wrongID.",
         )(data=str(time_window))
         return response.json()
 
+
 class PFSProjectUsageClientService(ClientService[str], ProjectRequestMixin):
     def __init__(self, template: Template, **kwargs):
         self.initialize_project()
         super().__init__(template, project_id=self.project_id, **kwargs)
 
-    def get_deployment_usage(self) -> dict:
+    def get_deployment_usage(self) -> Dict[str, Any]:
         response = safe_request(
             self.list,
             err_prefix=f"Deployment usages are not found in the project.",

--- a/pfcli/service/client/group.py
+++ b/pfcli/service/client/group.py
@@ -5,7 +5,7 @@
 import json
 import uuid
 from string import Template
-from typing import Dict, List, Optional
+from typing import Any, Dict, List, Optional
 from uuid import UUID
 
 from pfcli.service import CheckpointCategory, ModelFormCategory, StorageType
@@ -22,13 +22,13 @@ from pfcli.utils.validate import validate_storage_region
 
 
 class GroupClientService(ClientService):
-    def create_group(self, name: str) -> dict:
+    def create_group(self, name: str) -> Dict[str, Any]:
         response = safe_request(
             self.post, err_prefix="Failed to post an organization."
         )(data=json.dumps({"name": name, "hosting_type": "hosted"}))
         return response.json()
 
-    def get_group(self, pf_group_id: uuid.UUID) -> dict:
+    def get_group(self, pf_group_id: uuid.UUID) -> Dict[str, Any]:
         response = safe_request(
             self.retrieve, err_prefix="Failed to get an organization."
         )(pk=pf_group_id)
@@ -44,7 +44,7 @@ class GroupClientService(ClientService):
             path="invite/confirm", json={"email_token": token, "key": key}
         )
 
-    def get_users(self, pf_group_id: uuid.UUID, username: str) -> List[dict]:
+    def get_users(self, pf_group_id: uuid.UUID, username: str) -> List[Dict[str, Any]]:
         get_response_dict = safe_request(
             self.list, err_prefix="Failed to get user in organization"
         )
@@ -52,7 +52,7 @@ class GroupClientService(ClientService):
             get_response_dict, path=f"{pf_group_id}/pf_user", search=username
         )
 
-    def list_users(self, pf_group_id: uuid.UUID) -> List[dict]:
+    def list_users(self, pf_group_id: uuid.UUID) -> List[Dict[str, Any]]:
         get_response_dict = safe_request(
             self.list, err_prefix="Failed to list users in organization"
         )
@@ -64,13 +64,13 @@ class GroupProjectClientService(ClientService, GroupRequestMixin):
         self.initialize_group()
         super().__init__(template, pf_group_id=self.group_id, **kwargs)
 
-    def create_project(self, name: str) -> dict:
+    def create_project(self, name: str) -> Dict[str, Any]:
         response = safe_request(self.post, err_prefix="Failed to post a project.")(
             data=json.dumps({"name": name})
         )
         return response.json()
 
-    def list_projects(self) -> List[dict]:
+    def list_projects(self) -> List[Dict[str, Any]]:
         get_response_dict = safe_request(
             self.list, err_prefix="Failed to list projects."
         )
@@ -82,7 +82,7 @@ class PFTGroupVMConfigClientService(ClientService, GroupRequestMixin):
         self.initialize_group()
         super().__init__(template, group_id=self.group_id, **kwargs)
 
-    def list_vm_configs(self) -> List[dict]:
+    def list_vm_configs(self) -> List[Dict[str, Any]]:
         response = safe_request(
             self.list, err_prefix="Failed to list available VM list."
         )()
@@ -115,7 +115,9 @@ class GroupProjectCheckpointClientService(
             **kwargs,
         )
 
-    def list_checkpoints(self, category: Optional[CheckpointCategory]) -> List[dict]:
+    def list_checkpoints(
+        self, category: Optional[CheckpointCategory]
+    ) -> List[Dict[str, Any]]:
         request_data = {}
         if category is not None:
             request_data["category"] = category.value
@@ -134,11 +136,11 @@ class GroupProjectCheckpointClientService(
         credential_id: UUID,
         iteration: int,
         storage_name: str,
-        files: List[dict],
-        dist_config: dict,
-        data_config: dict,
-        job_setting_config: Optional[dict],
-    ) -> dict:
+        files: List[Dict[str, Any]],
+        dist_config: Dict[str, Any],
+        data_config: Dict[str, Any],
+        job_setting_config: Optional[Dict[str, Any]],
+    ) -> Dict[str, Any]:
         validate_storage_region(vendor, region)
 
         request_data = {

--- a/pfcli/service/client/job.py
+++ b/pfcli/service/client/job.py
@@ -103,7 +103,7 @@ class ProjectJobCheckpointClientService(ClientService, ProjectRequestMixin):
         self.initialize_project()
         super().__init__(template, project_id=self.project_id, **kwargs)
 
-    def list_checkpoints(self) -> List[dict]:
+    def list_checkpoints(self) -> List[Dict[str, Any]]:
         response = safe_request(self.list, err_prefix="Failed to list checkpoints.")()
         return response.json()
 
@@ -113,7 +113,7 @@ class ProjectJobArtifactClientService(ClientService, ProjectRequestMixin):
         self.initialize_project()
         super().__init__(template, project_id=self.project_id, **kwargs)
 
-    def list_artifacts(self) -> List[dict]:
+    def list_artifacts(self) -> List[Dict[str, Any]]:
         response = safe_request(self.list, err_prefix="Failed to list artifacts.")()
         return response.json()
 
@@ -125,7 +125,7 @@ class ProjectJobArtifactClientService(ClientService, ProjectRequestMixin):
             url_template.render(**self.url_kwargs), headers=get_auth_header()
         )
 
-    def get_artifact_download_url(self, artifact_id: int) -> dict:
+    def get_artifact_download_url(self, artifact_id: int) -> Dict[str, Any]:
         response = safe_request(
             self.download, err_prefix="Failed to get artifact download url"
         )(artifact_id)
@@ -139,7 +139,7 @@ class JobTemplateClientService(ClientService[UUID]):
         )()
         return [template["name"] for template in response.json()]
 
-    def get_job_template_by_name(self, name: str) -> Optional[dict]:
+    def get_job_template_by_name(self, name: str) -> Optional[Dict[str, Any]]:
         response = safe_request(
             self.list, err_prefix="Failed to list job template names."
         )()
@@ -148,7 +148,7 @@ class JobTemplateClientService(ClientService[UUID]):
                 return template
         return None
 
-    def get_job_template(self, job_template_id: UUID) -> dict:
+    def get_job_template(self, job_template_id: UUID) -> Dict[str, Any]:
         response = safe_request(
             self.retrieve,
             err_prefix=f"Job template (ID: {job_template_id}) is not found.",
@@ -169,7 +169,7 @@ class ProjectJobClientService(ClientService, ProjectRequestMixin):
         vm: Optional[str] = None,
         statuses: Optional[Tuple[JobStatus]] = None,
         user_ids: Optional[List[UUID]] = None,
-    ) -> List[dict]:
+    ) -> List[Dict[str, Any]]:
         params = {
             "created_at.since": since,
             "created_at.until": until,
@@ -185,7 +185,7 @@ class ProjectJobClientService(ClientService, ProjectRequestMixin):
             **params,
         )
 
-    def run_job(self, config: Dict, workspace_dir: Optional[Path]) -> dict:
+    def run_job(self, config: Dict, workspace_dir: Optional[Path]) -> Dict[str, Any]:
         job_request = safe_request(self.post, err_prefix="Failed to run job.")
         if workspace_dir is not None:
             typer.secho("Preparing workspace directory...", fg=typer.colors.MAGENTA)
@@ -225,7 +225,7 @@ class ProjectJobClientService(ClientService, ProjectRequestMixin):
             pk=job_number
         )
 
-    def get_job(self, job_number: int) -> dict:
+    def get_job(self, job_number: int) -> Dict[str, Any]:
         response = safe_request(
             self.retrieve, err_prefix=f"Failed to get job ({job_number})."
         )(pk=job_number)
@@ -249,7 +249,7 @@ class ProjectJobClientService(ClientService, ProjectRequestMixin):
         log_types: Optional[List[str]] = None,
         machines: Optional[List[int]] = None,
         content: Optional[str] = None,
-    ) -> List[dict]:
+    ) -> List[Dict[str, Any]]:
         request_data: Dict[str, Any] = {"limit": num_records}
         if head:
             request_data["ascending"] = "true"

--- a/pfcli/service/client/metrics.py
+++ b/pfcli/service/client/metrics.py
@@ -4,7 +4,7 @@
 
 import json
 from datetime import datetime
-from typing import List, TypeVar
+from typing import Dict, List, TypeVar
 
 from pfcli.service.client.base import ClientService, safe_request
 from pfcli.utils.format import datetime_to_simple_string, utc_to_local
@@ -18,7 +18,7 @@ class MetricsClientService(ClientService):
     def list_metrics(
         self,
         job_id: int,
-    ) -> List[dict[str, str]]:
+    ) -> List[Dict[str, str]]:
         """Show available metrics."""
         fields = f'task: "{job_id}", telemetry: null, start: null, until: null'
         query = f"{{ sampleQuery(fields: {{ {fields} }}) {{name}} }}"
@@ -37,7 +37,7 @@ class MetricsClientService(ClientService):
         job_id: int,
         name: str,
         limit: int = 10,
-    ) -> List[dict[str, MetricsType]]:
+    ) -> List[Dict[str, MetricsType]]:
         fields = f'task: "{job_id}", telemetry: "{name}", limit: {limit}, goal: LAST'
         output_type = "created, value, labels {key, value}"
         query = f"{{ representativeSamples(fields:{{ {fields} }}){{ {output_type} }} }}"

--- a/pfcli/service/client/project.py
+++ b/pfcli/service/client/project.py
@@ -5,7 +5,7 @@
 
 from requests import HTTPError
 from string import Template
-from typing import List, Optional
+from typing import Any, Dict, List, Optional
 from uuid import UUID
 
 from pfcli.service import (
@@ -27,7 +27,7 @@ from pfcli.utils.request import paginated_get
 from pfcli.utils.validate import validate_storage_region
 
 
-def find_project_id(projects: List[dict], project_name: str) -> UUID:
+def find_project_id(projects: List[Dict[str, Any]], project_name: str) -> UUID:
     for project in projects:
         if project["name"] == project_name:
             return UUID(project["id"])
@@ -35,7 +35,7 @@ def find_project_id(projects: List[dict], project_name: str) -> UUID:
 
 
 class ProjectClientService(ClientService[UUID]):
-    def get_project(self, pf_project_id: UUID) -> dict:
+    def get_project(self, pf_project_id: UUID) -> Dict[str, Any]:
         response = safe_request(self.retrieve, err_prefix="Failed to get a project.")(
             pk=pf_project_id
         )
@@ -54,7 +54,7 @@ class ProjectClientService(ClientService[UUID]):
             pk=pf_project_id
         )
 
-    def list_users(self, pf_project_id: UUID) -> List[dict]:
+    def list_users(self, pf_project_id: UUID) -> List[Dict[str, Any]]:
         get_response_dict = safe_request(
             self.list, err_prefix="Failed to list users in the current project"
         )
@@ -66,7 +66,7 @@ class ProjectDataClientService(ClientService[int], ProjectRequestMixin):
         self.initialize_project()
         super().__init__(template, project_id=self.project_id, **kwargs)
 
-    def list_datasets(self) -> List[dict]:
+    def list_datasets(self) -> List[Dict[str, Any]]:
         response = safe_request(self.list, err_prefix="Failed to list dataset info.")()
         return response.json()
 
@@ -84,10 +84,10 @@ class ProjectDataClientService(ClientService[int], ProjectRequestMixin):
         region: str,
         storage_name: str,
         credential_id: Optional[UUID],
-        metadata: dict,
-        files: List[dict],
+        metadata: Dict[str, Any],
+        files: List[Dict[str, Any]],
         active: bool,
-    ) -> dict:
+    ) -> Dict[str, Any]:
         validate_storage_region(vendor, region)
 
         vendor_name = storage_type_map[vendor]
@@ -116,7 +116,7 @@ class PFTProjectVMQuotaClientService(ClientService, ProjectRequestMixin):
         self,
         vendor: Optional[CloudType] = None,
         device_type: Optional[str] = None,
-    ) -> List[dict]:
+    ) -> List[Dict[str, Any]]:
         response = safe_request(self.list, err_prefix="Failed to list VM quota info.")()
         vm_dict_list = response.json()
         if vendor is not None:
@@ -141,7 +141,7 @@ class ProjectCredentialClientService(ClientService, ProjectRequestMixin):
         self.initialize_project()
         super().__init__(template, project_id=self.project_id, **kwargs)
 
-    def list_credentials(self, cred_type: CredType) -> List[dict]:
+    def list_credentials(self, cred_type: CredType) -> List[Dict[str, Any]]:
         type_name = cred_type_map[cred_type]
         response = safe_request(
             self.list, err_prefix=f"Failed to list credential for {cred_type}."
@@ -149,8 +149,8 @@ class ProjectCredentialClientService(ClientService, ProjectRequestMixin):
         return response.json()
 
     def create_credential(
-        self, cred_type: CredType, name: str, type_version: int, value: dict
-    ) -> dict:
+        self, cred_type: CredType, name: str, type_version: int, value: Dict[str, Any]
+    ) -> Dict[str, Any]:
         type_name = cred_type_map[cred_type]
         request_data = {
             "type": type_name,
@@ -171,7 +171,7 @@ class PFTProjectVMConfigClientService(ClientService[int], ProjectRequestMixin):
 
     def list_vm_locks(
         self, vm_config_id: int, lock_status_list: List[LockStatus]
-    ) -> List[dict]:
+    ) -> List[Dict[str, Any]]:
         status_param = ",".join(lock_status_list)
         response = safe_request(self.list, err_prefix="Failed to inspect locked VMs.")(
             path=f"{vm_config_id}/vm_lock/", params={"status": status_param}

--- a/pfcli/service/client/user.py
+++ b/pfcli/service/client/user.py
@@ -3,7 +3,7 @@
 """PeriFlow UserClient Service"""
 
 from string import Template
-from typing import List
+from typing import Any, Dict, List
 from uuid import UUID
 
 from pfcli.service import GroupRole, ProjectRole
@@ -63,7 +63,7 @@ class UserClientService(ClientService, UserRequestMixin):
             json={"privilege_level": privilege_level.value},
         )
 
-    def get_project_membership(self, pf_project_id: UUID) -> dict:
+    def get_project_membership(self, pf_project_id: UUID) -> Dict[str, Any]:
         response = safe_request(
             self.retrieve, err_prefix="Failed identify member in project"
         )(
@@ -81,7 +81,9 @@ class UserClientService(ClientService, UserRequestMixin):
         )
 
     def delete_from_project(
-        self, pf_user_id: UUID, pf_project_id: UUID,
+        self,
+        pf_user_id: UUID,
+        pf_project_id: UUID,
     ) -> None:
         safe_request(self.delete, err_prefix="Failed to remove user from proejct")(
             pk=pf_user_id,
@@ -106,7 +108,7 @@ class UserGroupClientService(ClientService, UserRequestMixin):
         self.initialize_user()
         super().__init__(template, pf_user_id=self.user_id, **kwargs)
 
-    def get_group_info(self) -> dict:
+    def get_group_info(self) -> Dict[str, Any]:
         response = safe_request(self.list, err_prefix="Failed to get my group info.")()
         return response.json()[0]
 
@@ -119,7 +121,7 @@ class UserGroupProjectClientService(ClientService, UserRequestMixin, GroupReques
             template, pf_user_id=self.user_id, pf_group_id=self.group_id, **kwargs
         )
 
-    def list_projects(self) -> List[dict]:
+    def list_projects(self) -> List[Dict[str, Any]]:
         get_response_dict = safe_request(
             self.list, err_prefix="Failed to list projects."
         )

--- a/pfcli/service/cloud.py
+++ b/pfcli/service/cloud.py
@@ -3,6 +3,7 @@
 """PeriFlow Cloud Service"""
 
 from typing import (
+    Any,
     Callable,
     Dict,
     List,
@@ -33,7 +34,7 @@ class CloudStorageHelper:
 
     def list_storage_files(
         self, storage_name: str, path_prefix: Optional[str] = None
-    ) -> List[dict]:
+    ) -> List[Dict[str, Any]]:
         raise NotImplementedError  # pragma: no cover
 
 
@@ -49,7 +50,7 @@ class AWSCloudStorageHelper(CloudStorageHelper):
 
     def list_storage_files(
         self, storage_name: str, path_prefix: Optional[str] = None
-    ) -> List[dict]:
+    ) -> List[Dict[str, Any]]:
         if not self._check_aws_bucket_exists(storage_name):
             secho_error_and_exit(f"Bucket {storage_name} does not exist")
 
@@ -133,7 +134,7 @@ vendor_helper_map: Dict[StorageType, Tuple[Type[C], Callable[[Dict[str, str]], T
 }
 
 
-def build_storage_helper(vendor: StorageType, credential_json: dict) -> C:
+def build_storage_helper(vendor: StorageType, credential_json: Dict[str, Any]) -> C:
     cls, client_build_fn = vendor_helper_map[vendor]
     client = client_build_fn(credential_json)
     return cls(client)

--- a/pfcli/service/formatter.py
+++ b/pfcli/service/formatter.py
@@ -28,12 +28,12 @@ from rich.console import Console, RenderableType
 T = TypeVar("T", bound=Union[int, str])
 
 
-def get_value(data: dict, key: str) -> T:
+def get_value(data: Dict[str, Any], key: str) -> T:
     """Get value of `key` from `data`.
     Unlike dict.get method, it is available to access the nested value in `data`.
 
     Args:
-        data (dict): Data to read.
+        data (Dict[str, Any]): Data to read.
         key (str): Dot(.)-separated nested keys in data to access the value.
 
     Returns:
@@ -79,11 +79,11 @@ class ListFormatter(Formatter):
         self._styling_map: Dict[str, Dict[str, Any]] = {}
         self._substitution_rule: Dict[str, str] = {}
 
-    def render(self, data: List[dict], show_detail: bool = False) -> None:
+    def render(self, data: List[Dict[str, Any]], show_detail: bool = False) -> None:
         raise NotImplementedError  # pragma: no cover
 
     def get_renderable(
-        self, data: List[dict], show_detail: bool = False
+        self, data: List[Dict[str, Any]], show_detail: bool = False
     ) -> RenderableType:
         raise NotImplementedError  # pragma: no cover
 
@@ -109,15 +109,17 @@ class TableFormatter(ListFormatter):
         self._table = Table(title=self.name, caption=self.caption, box=box.SIMPLE)
         self._make_header(show_detail)
 
-    def render(self, data: List[dict], show_detail: bool = False) -> None:
+    def render(self, data: List[Dict[str, Any]], show_detail: bool = False) -> None:
         self._build_table(data, show_detail)
         self._console.print(self._table)
 
-    def get_renderable(self, data: List[dict], show_detail: bool = False) -> Table:
+    def get_renderable(
+        self, data: List[Dict[str, Any]], show_detail: bool = False
+    ) -> Table:
         self._build_table(data, show_detail)
         return self._table
 
-    def _build_table(self, data: List[dict], show_detail: bool):
+    def _build_table(self, data: List[Dict[str, Any]], show_detail: bool):
         self._init(show_detail)
 
         for d in data:
@@ -143,21 +145,27 @@ class PanelFormatter(ListFormatter):
 
     subtitle: Optional[str] = None
 
-    def render(self, data: Union[List[dict], dict], show_detail: bool = False) -> None:
+    def render(
+        self,
+        data: Union[List[Dict[str, Any]], Dict[str, Any]],
+        show_detail: bool = False,
+    ) -> None:
         if not isinstance(data, list):
             data = [data]
         self._build_panel(data, show_detail)
         self._console.print(self._panel)
 
     def get_renderable(
-        self, data: Union[List[dict], dict], show_detail: bool = False
+        self,
+        data: Union[List[Dict[str, Any]], Dict[str, Any]],
+        show_detail: bool = False,
     ) -> Panel:
         if not isinstance(data, list):
             data = [data]
         self._build_panel(data, show_detail)
         return self._panel
 
-    def _build_panel(self, data: List[dict], show_detail: bool):
+    def _build_panel(self, data: List[Dict[str, Any]], show_detail: bool):
         headers = self.headers + self.extra_headers if show_detail else self.headers
         table = Table(box=None, show_header=False)
         table.add_column("k", style="dim bold")
@@ -218,15 +226,15 @@ class TreeFormatter(Formatter):
         super().__init__(name=name)
         self._root = "/" + root.lstrip("/")
 
-    def render(self, data: List[dict]) -> None:
+    def render(self, data: List[Dict[str, Any]]) -> None:
         self._build_renderable(data)
         self._console.print(self._panel)
 
-    def get_renderable(self, data: List[dict]) -> Panel:
+    def get_renderable(self, data: List[Dict[str, Any]]) -> Panel:
         self._build_renderable(data)
         return self._panel
 
-    def _build_tree(self, data: List[dict]) -> Tree:
+    def _build_tree(self, data: List[Dict[str, Any]]) -> Tree:
         root = Tree("/")
         paths = [
             f"{d['path']}"
@@ -244,7 +252,7 @@ class TreeFormatter(Formatter):
             find_and_insert(root, edges)
         return root
 
-    def _build_renderable(self, data: List[dict]) -> None:
+    def _build_renderable(self, data: List[Dict[str, Any]]) -> None:
         root = self._build_tree(data)
         self._panel = Panel(root, title=self.name)
 
@@ -253,13 +261,13 @@ class TreeFormatter(Formatter):
 class JSONFormatter(Formatter):
     """JSON formatter for visualizing JSON data."""
 
-    def render(self, data: dict) -> None:
+    def render(self, data: Dict[str, Any]) -> None:
         self._build_json(data)
         self._console.print(self._panel)
 
-    def get_renderable(self, data: List[dict]) -> Panel:
+    def get_renderable(self, data: List[Dict[str, Any]]) -> Panel:
         self._build_json(data)
         return self._panel
 
-    def _build_json(self, data: dict) -> None:
+    def _build_json(self, data: Dict[str, Any]) -> None:
         self._panel = Panel(JSON(json.dumps(data)), title=self.name)

--- a/pfcli/utils/fs.py
+++ b/pfcli/utils/fs.py
@@ -8,7 +8,7 @@ from datetime import datetime
 from dateutil.tz import tzlocal
 import os
 from pathlib import Path
-from typing import List
+from typing import Any, Dict, List
 import zipfile
 
 import pathspec
@@ -67,7 +67,7 @@ def storage_path_to_local_path(
     return str(source_path / Path(storage_path.split("/", 1)[1]))
 
 
-def get_file_info(storage_path: str, source_path: Path, expand: bool) -> dict:
+def get_file_info(storage_path: str, source_path: Path, expand: bool) -> Dict[str, Any]:
     loacl_path = storage_path_to_local_path(storage_path, source_path, expand)
     return {
         "name": os.path.basename(storage_path),

--- a/pfcli/utils/request.py
+++ b/pfcli/utils/request.py
@@ -2,7 +2,7 @@
 
 """PeriFlow CLI API Request Utilities"""
 
-from typing import Callable, List, Optional
+from typing import Any, Dict, Callable, List, Optional
 
 from requests.exceptions import HTTPError
 from requests.models import Response
@@ -36,7 +36,7 @@ def decode_http_err(exc: HTTPError) -> str:
 
 def paginated_get(
     response_getter: Callable[..., Response], path: Optional[str] = None, **params
-) -> List[dict]:
+) -> List[Dict[str, Any]]:
     """Pagination listing"""
     response_dict = response_getter(path=path, params={**params}).json()
     items = response_dict["results"]

--- a/pfcli/utils/url.py
+++ b/pfcli/utils/url.py
@@ -4,14 +4,14 @@
 
 from urllib.parse import urljoin
 
-periflow_api_server = "https://api-dev.friendli.ai/api/"
-periflow_ws_server = "wss://api-ws-dev.friendli.ai/ws/"
+periflow_api_server = "https://api-staging.friendli.ai/api/"
+periflow_ws_server = "wss://api-ws-staging.friendli.ai/ws/"
 periflow_discuss_url = "https://discuss.friendli.ai/"
-periflow_mr_server = "https://pfmodelregistry-dev.friendli.ai/"
-periflow_serve_server = "https://pfs-dev.friendli.ai/"
-periflow_auth_server = "https://pfauth-dev.friendli.ai/"
-periflow_meter_server = "https://pfmeter-dev.friendli.ai/"
-periflow_observatory_server = "https://pfo-dev.friendli.ai/"
+periflow_mr_server = "https://pfmodelregistry-staging.friendli.ai/"
+periflow_serve_server = "https://pfs-staging.friendli.ai/"
+periflow_auth_server = "https://pfauth-staging.friendli.ai/"
+periflow_meter_server = "https://pfmeter-staging.friendli.ai/"
+periflow_observatory_server = "https://pfo-staging.friendli.ai/"
 
 
 def get_auth_uri(path: str) -> str:

--- a/pfcli/utils/url.py
+++ b/pfcli/utils/url.py
@@ -4,14 +4,14 @@
 
 from urllib.parse import urljoin
 
-periflow_api_server = "https://api-staging.friendli.ai/api/"
-periflow_ws_server = "wss://api-ws-staging.friendli.ai/ws/"
+periflow_api_server = "https://api-dev.friendli.ai/api/"
+periflow_ws_server = "wss://api-ws-dev.friendli.ai/ws/"
 periflow_discuss_url = "https://discuss.friendli.ai/"
-periflow_mr_server = "https://pfmodelregistry-staging.friendli.ai/"
-periflow_serve_server = "https://pfs-staging.friendli.ai/"
-periflow_auth_server = "https://pfauth-staging.friendli.ai/"
-periflow_meter_server = "https://pfmeter-staging.friendli.ai/"
-periflow_observatory_server = "https://pfo-staging.friendli.ai/"
+periflow_mr_server = "https://pfmodelregistry-dev.friendli.ai/"
+periflow_serve_server = "https://pfs-dev.friendli.ai/"
+periflow_auth_server = "https://pfauth-dev.friendli.ai/"
+periflow_meter_server = "https://pfmeter-dev.friendli.ai/"
+periflow_observatory_server = "https://pfo-dev.friendli.ai/"
 
 
 def get_auth_uri(path: str) -> str:

--- a/setup.py
+++ b/setup.py
@@ -79,7 +79,7 @@ setup(
             "pf = pfcli:app",
         ]
     },
-    python_requires='>=3.6',
+    python_requires='>=3.8',
     include_package_data=True,
     install_requires=COMMON_DEPS,
     extras_require={

--- a/test/service/client/test_group.py
+++ b/test/service/client/test_group.py
@@ -3,7 +3,7 @@
 """Test GroupClient Service"""
 
 from copy import deepcopy
-from tokenize import group
+from typing import Any, Dict
 import uuid
 
 import pytest
@@ -231,7 +231,7 @@ def test_group_checkpoint_list_checkpoints(
     requests_mock: requests_mock.Mocker,
     group_project_checkpoint_client: GroupProjectCheckpointClientService,
 ):
-    def build_response_item(category: str, vendor: str, region: str) -> dict:
+    def build_response_item(category: str, vendor: str, region: str) -> Dict[str, Any]:
         return {
             "id": "22222222-2222-2222-2222-222222222222",
             "user_id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",

--- a/test/service/test_cloud.py
+++ b/test/service/test_cloud.py
@@ -3,6 +3,7 @@
 """Test Client Service"""
 
 from datetime import datetime
+from typing import Any, Dict
 from unittest.mock import Mock
 
 import pytest
@@ -20,7 +21,7 @@ from pfcli.service.cloud import (
 
 
 @pytest.fixture
-def s3_credential_json() -> dict:
+def s3_credential_json() -> Dict[str, Any]:
     return {
         "aws_access_key_id": "fake_aws_access_key_id",
         "aws_secret_access_key": "fake_aws_secret_access_key",
@@ -29,7 +30,7 @@ def s3_credential_json() -> dict:
 
 
 @pytest.fixture
-def blob_credential_json() -> dict:
+def blob_credential_json() -> Dict[str, Any]:
     return {
         "storage_account_name": "fakestorageaccountname",
         "storage_account_key": "fake_storage_account_key",
@@ -61,7 +62,7 @@ def azure_storage_helper(blob_client_mock) -> AzureCloudStorageHelper:
     return AzureCloudStorageHelper(blob_client_mock)
 
 
-def test_build_storage_helper(s3_credential_json: dict, blob_credential_json: dict):
+def test_build_storage_helper(s3_credential_json: Dict[str, Any], blob_credential_json: Dict[str, Any]):
     aws_storage_helper = build_storage_helper(StorageType.S3, s3_credential_json)
     assert isinstance(aws_storage_helper, AWSCloudStorageHelper)
     assert isinstance(aws_storage_helper.client, BaseClient)


### PR DESCRIPTION
Changes:

- Minimum python version is set to 3.8.
- Use the old version typing.

Tested on:

- python3.8
- python3.9
- python3.10
