### PR TITLE
Support removing a member from organization

### DIFF
--- a/pfcli/project.py
+++ b/pfcli/project.py
@@ -189,11 +189,24 @@ def delete_user(
         ...,
         help="Username to delete from the current working project",
     ),
+    force: bool = typer.Option(
+        False,
+        "--force",
+        "-f",
+        help="Forcefully delete without confirmation prompt",
+    ),
 ):
     user_client: UserClientService = build_client(ServiceType.USER)
 
     org_id, project_id = _check_project_and_get_id()
     user_id = _get_org_user_id_by_name(org_id, username)
+
+    if not force:
+        do_delete = typer.confirm(
+            f"Are you sure to remove user({username}) from the project?"
+        )
+        if not do_delete:
+            raise typer.Abort()
 
     user_client.delete_from_project(user_id, project_id)
     typer.secho(f"User is successfully deleted from project", fg=typer.colors.BLUE)

--- a/pfcli/service/client/user.py
+++ b/pfcli/service/client/user.py
@@ -80,14 +80,14 @@ class UserClientService(ClientService, UserRequestMixin):
             json={"access_level": access_level.value},
         )
 
-    def delete_from_project(
-        self,
-        pf_user_id: UUID,
-        pf_project_id: UUID,
-    ) -> None:
+    def delete_from_org(self, pf_user_id: UUID, pf_org_id: UUID) -> None:
+        safe_request(self.delete, err_prefix="Failed to remove user from organization")(
+            pk=pf_user_id, path=f"pf_group/{pf_org_id}"
+        )
+
+    def delete_from_project(self, pf_user_id: UUID, pf_project_id: UUID) -> None:
         safe_request(self.delete, err_prefix="Failed to remove user from proejct")(
-            pk=pf_user_id,
-            path=f"pf_project/{pf_project_id}",
+            pk=pf_user_id, path=f"pf_project/{pf_project_id}"
         )
 
     def set_project_privilege(


### PR DESCRIPTION
This PR adds a new CLI command `pf org delete-user [USERNAME]` which evicts a member from the organization. This command is available only for owners of the organization.