### PR TITLE
Enforce the latest CLI version

### DIFF
--- a/pfcli/main.py
+++ b/pfcli/main.py
@@ -37,12 +37,14 @@ from pfcli.service.client import (
 from pfcli.service.formatter import PanelFormatter
 from pfcli.utils.format import secho_error_and_exit
 from pfcli.utils.url import get_uri
+from pfcli.utils.validate import validate_cli_version
 
 app = typer.Typer(
     help="Welcome to PeriFlow 🤗",
     no_args_is_help=True,
     context_settings={"help_option_names": ["-h", "--help"]},
     add_completion=False,
+    callback=validate_cli_version,
 )
 
 app.add_typer(credential.app, name="credential", help="Manage credentials")

--- a/pfcli/utils/validate.py
+++ b/pfcli/utils/validate.py
@@ -3,12 +3,14 @@
 """PeriFlow CLI Validation Utilities"""
 
 from datetime import datetime
+from importlib.metadata import version
 from typing import List, Optional
 
 import typer
 
 from pfcli.service import CloudType, cloud_region_map, StorageType, storage_region_map
 from pfcli.utils.format import secho_error_and_exit
+from pfcli.utils.version import get_latest_cli_version, is_latest_cli_version, PERIFLOW_CLI_NAME
 
 
 def validate_storage_region(vendor: StorageType, region: str):
@@ -55,3 +57,13 @@ def validate_parallelism_order(value: str) -> List[str]:
             "Invalid Argument: parallelism_order should contain 'pp', 'dp', 'mp'"
         )
     return parallelism_order
+
+
+def validate_cli_version() -> None:
+    installed_version = version(PERIFLOW_CLI_NAME)
+    if not is_latest_cli_version(installed_version):
+        latest_version = get_latest_cli_version()
+        secho_error_and_exit(
+            f"CLI version({installed_version}) is deprecated. "
+            f"Please install the latest version({latest_version}) with 'pip install {PERIFLOW_CLI_NAME}=={latest_version} -U --no-cache-dir'."
+        )

--- a/pfcli/utils/version.py
+++ b/pfcli/utils/version.py
@@ -1,0 +1,22 @@
+import json
+from typing import Union
+from urllib.request import urlopen
+
+from packaging.version import LegacyVersion, Version, parse as parse_version
+
+
+PERIFLOW_CLI_NAME = "periflow-cli"
+PYPI_BASE_URL = "https://pypi.org/pypi"
+
+
+def is_latest_cli_version(ver: str) -> bool:
+    version = parse_version(ver)
+    latest_version = get_latest_cli_version()
+
+    return version == latest_version
+
+
+def get_latest_cli_version() -> Union[LegacyVersion, Version]:
+    pypi_info = json.loads(urlopen(f"{PYPI_BASE_URL}/{PERIFLOW_CLI_NAME}/json").read())
+    latest_ver_string = pypi_info["info"]["version"]
+    return parse_version(latest_ver_string)

--- a/pfcli/utils/version.py
+++ b/pfcli/utils/version.py
@@ -1,8 +1,7 @@
 import json
-from typing import Union
 from urllib.request import urlopen
 
-from packaging.version import LegacyVersion, Version, parse as parse_version
+from packaging.version import _BaseVersion, parse as parse_version
 
 
 PERIFLOW_CLI_NAME = "periflow-cli"
@@ -16,7 +15,7 @@ def is_latest_cli_version(ver: str) -> bool:
     return version == latest_version
 
 
-def get_latest_cli_version() -> Union[LegacyVersion, Version]:
+def get_latest_cli_version() -> _BaseVersion:
     pypi_info = json.loads(urlopen(f"{PYPI_BASE_URL}/{PERIFLOW_CLI_NAME}/json").read())
     latest_ver_string = pypi_info["info"]["version"]
     return parse_version(latest_ver_string)


### PR DESCRIPTION
This PR makes every CLI command check the latest CLI release version from PyPi and raises an error if the installed version is not the latest.
For example,

```
$ pip list | grep periflow-cli
periflow-cli           0.1.9

$ pf job list
CLI version(0.1.9) is deprecated. Please install the latest version(0.1.10) with 'pip install periflow-cli==0.1.10 -U --no-cache-dir'.
```