### PR TITLE
Run Periflow CLI unit tests in github actions

### DIFF
--- a/.github/workflows/pf-cli.yaml
+++ b/.github/workflows/pf-cli.yaml
@@ -12,7 +12,6 @@ on:
   push:
     branches:
       - main
-      - cli-ci
   pull_request:
     types:
       - opened

--- a/.github/workflows/pf-cli.yaml
+++ b/.github/workflows/pf-cli.yaml
@@ -1,0 +1,42 @@
+# Copyright (c) 2023-present, FriendliAI Inc. All rights reserved.
+#
+# This workflow will install Python dependencies, run tests with multiple versions of Python
+
+name: Periflow CLI
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+on:
+  push:
+    branches:
+      - main
+      - cli-ci
+  pull_request:
+    types:
+      - opened
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.8", "3.9", "3.10"]
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python ${{ matrix.python-version }}
+      id: setup-python
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Install Periflow CLI
+      run: pip install periflow-cli
+
+
+    - name: Run Unit Tests
+      run: |
+        pip install pytest
+        pytest periflow-cli/test

--- a/.github/workflows/pf-cli.yaml
+++ b/.github/workflows/pf-cli.yaml
@@ -33,10 +33,10 @@ jobs:
         python-version: ${{ matrix.python-version }}
 
     - name: Install Periflow CLI
-      run: pip install periflow-cli
+      run: |
+        pip install .[test]
 
 
     - name: Run Unit Tests
       run: |
-        pip install pytest
-        pytest periflow-cli/test
+        pytest ./test


### PR DESCRIPTION
This PR enables github actions on three different python versions (3.8, 3.9, and 3.10).