### PR TITLE
Fix billing summary results

### DIFF
--- a/pfcli/billing.py
+++ b/pfcli/billing.py
@@ -11,7 +11,7 @@ import typer
 
 from pfcli.service import PeriFlowService, ServiceType
 from pfcli.service.client import build_client
-from pfcli.service.client.billing import PFTBillingClientService, TimeGranularity
+from pfcli.service.client.billing import PFTBillingClientService, Scope, TimeGranularity
 from pfcli.service.formatter import PanelFormatter, TableFormatter
 from pfcli.utils.format import (
     datetime_to_simple_string,
@@ -42,19 +42,10 @@ def billing_summary_for_job(
     year: int,
     month: int,
     day: Optional[int],
-    view_project: bool,
-    view_organization: bool,
+    scope: Scope,
     time_granularity: Optional[TimeGranularity],
 ):
     client: PFTBillingClientService = build_client(ServiceType.PFT_BILLING_SUMMARY)
-
-    agg_by = "user_id"
-
-    if view_project:
-        agg_by = "project_id"
-
-    if view_organization:
-        agg_by = "organization_id"
 
     try:
         if day is None:
@@ -72,7 +63,7 @@ def billing_summary_for_job(
     prices = client.list_prices(
         start_date=start_date.isoformat(),
         end_date=end_date.isoformat(),
-        agg_by=agg_by,
+        scope=scope,
         time_granularity=time_granularity,
     )
 
@@ -102,8 +93,7 @@ def billing_summary_for_deployment(
     year: int,
     month: int,
     day: Optional[int],
-    view_project: bool,
-    view_organization: bool,
+    scope: Scope,
     time_granularity: Optional[TimeGranularity],
 ):
     # TODO: FILL ME
@@ -123,12 +113,7 @@ def summary(
     year: int = typer.Argument(...),
     month: int = typer.Argument(...),
     day: Optional[int] = typer.Argument(None),
-    view_project: bool = typer.Option(
-        False, "--project", "-p", help="View project-level cost summary."
-    ),
-    view_organization: bool = typer.Option(
-        False, "--organization", "-o", help="View organization-level cost summary."
-    ),
+    scope: Scope = typer.Option(Scope.USR, "--scope", help="Scope of the summary."),
     time_granularity: Optional[TimeGranularity] = typer.Option(
         None, "--time-granularity", "-t", help="View within the given time granularity."
     ),
@@ -142,7 +127,6 @@ def summary(
         year=year,
         month=month,
         day=day,
-        view_project=view_project,
-        view_organization=view_organization,
+        scope=scope,
         time_granularity=time_granularity,
     )

--- a/pfcli/service/client/billing.py
+++ b/pfcli/service/client/billing.py
@@ -21,6 +21,12 @@ class TimeGranularity(str, Enum):
     week = "week"
 
 
+class Scope(str, Enum):
+    ORG = "organization"
+    PRJ = "project"
+    USR = "user"
+
+
 class PFTBillingClientService(
     ClientService, GroupRequestMixin, ProjectRequestMixin, UserRequestMixin
 ):
@@ -34,7 +40,7 @@ class PFTBillingClientService(
         self,
         start_date: str,
         end_date: str,
-        agg_by: str = "user_id",
+        scope: Scope,
         time_granularity: Optional[TimeGranularity] = None,
     ) -> List[Dict[str, Any]]:
         params = {
@@ -44,7 +50,7 @@ class PFTBillingClientService(
             "start_date": start_date,
             "end_date": end_date,
             "time_unit": time_granularity,
-            "agg_by": agg_by,
+            "scope": scope.value,
         }
         return safe_request(self.list, err_prefix=f"Failed to get billing summary.")(
             params=params

--- a/test/service/client/test_billing.py
+++ b/test/service/client/test_billing.py
@@ -11,7 +11,7 @@ import typer
 
 from pfcli.service import ServiceType
 from pfcli.service.client import build_client
-from pfcli.service.client.billing import PFTBillingClientService
+from pfcli.service.client.billing import PFTBillingClientService, Scope
 
 
 @pytest.fixture
@@ -45,12 +45,14 @@ def test_billing_summary_client_get_summary(
         },
     )
     assert billing_summary_client.list_prices(
-        start_date=now.isoformat(), end_date=ten_days_after.isoformat()
+        scope=Scope.USR, start_date=now.isoformat(), end_date=ten_days_after.isoformat()
     )
 
     # Failed due to HTTP error
     requests_mock.get(url_template.render(), status_code=404)
     with pytest.raises(typer.Exit):
         assert billing_summary_client.list_prices(
-            start_date=now.isoformat(), end_date=ten_days_after.isoformat()
+            scope=Scope.USR,
+            start_date=now.isoformat(),
+            end_date=ten_days_after.isoformat(),
         )


### PR DESCRIPTION
Currently, the cost information shown by `pf billing summary` always displays a cost used by a user.
Now, by using the `--scope` option, we can check the correct costs used by the current {organization, project, user}.

The "scope" option determines the scope of the cost query. For example, if the "scope" is provided as "user", the response only includes the cost used by the user. Similarly, if the "scope" is "organization", the response includes the total cost used by all organization members across all projects.

> @pigbug419, @kdh0102, The API change should be considered when implementing the deployment cost summary afterward.