### PR TITLE
Deployment status formatting + default request config

### DIFF
--- a/pfcli/deployment.py
+++ b/pfcli/deployment.py
@@ -385,7 +385,10 @@ def create(
         help="Logging inference requests or not.",
     ),
     default_request_config_file: Optional[typer.FileText] = typer.Option(
-        None, "--default-request-config-file", help="Path to default request config"
+        None,
+        "--default-request-config-file",
+        "-drc",
+        help="Path to default request config",
     ),
 ):
     """Create a deployment object by using model checkpoint."""
@@ -434,6 +437,10 @@ def create(
         )
 
         file_size = os.stat(default_request_config_file.name).st_size
+        if file_size > 10737418240:  # 10 GiB
+            secho_error_and_exit(
+                f"Size of default request config file({file_size}bytes) should be <= 10 GiB"
+            )
         file_info = {
             "name": os.path.basename(default_request_config_file.name),
             "path": os.path.basename(default_request_config_file.name),

--- a/pfcli/deployment.py
+++ b/pfcli/deployment.py
@@ -16,7 +16,6 @@ import typer
 import yaml
 from dateutil.parser import parse
 from dateutil.tz import tzlocal
-from rich.text import Text
 from tqdm import tqdm
 
 from pfcli.context import get_current_project_id
@@ -47,7 +46,7 @@ from pfcli.utils.format import (
     extract_deployment_id_part,
     secho_error_and_exit,
 )
-from pfcli.utils.fs import download_file, get_file_info, upload_file
+from pfcli.utils.fs import download_file, upload_file
 from pfcli.utils.prompt import get_default_editor, open_editor
 
 app = typer.Typer(
@@ -95,7 +94,7 @@ deployment_panel = PanelFormatter(
     ],
     extra_fields=["error"],
     extra_headers=["error"],
-    substitute_only_exact_match=False,
+    substitute_exact_match_only=False,
 )
 
 deployment_table = TableFormatter(
@@ -113,7 +112,7 @@ deployment_table = TableFormatter(
     headers=["ID", "Name", "Status", "#Ready", "VM Type", "GPU Type", "#GPUs", "Start"],
     extra_fields=["error"],
     extra_headers=["error"],
-    substitute_only_exact_match=False,
+    substitute_exact_match_only=False,
 )
 
 deployment_metrics_table = TableFormatter(
@@ -445,9 +444,7 @@ def create(
         }
         file_id = group_file_client.create_misc_file(file_info=file_info)["id"]
 
-        upload_url = file_client.get_misc_file_upload_url(misc_file_id=file_id)[
-            "upload_url"
-        ]
+        upload_url = file_client.get_misc_file_upload_url(misc_file_id=file_id)
         with tqdm(
             total=file_size,
             unit="B",

--- a/pfcli/service/__init__.py
+++ b/pfcli/service/__init__.py
@@ -44,6 +44,8 @@ class ServiceType(str, Enum):
     PFS_VM = "PFS_VM"
     PFT_BILLING_SUMMARY = "BILLING_SUMMARY"
     METRICS = "METRICS"
+    FILE = "FILE"
+    GROUP_FILE = "GROUP_FILE"
 
 
 class GroupRole(str, Enum):

--- a/pfcli/service/client/__init__.py
+++ b/pfcli/service/client/__init__.py
@@ -26,6 +26,7 @@ from pfcli.service.client.deployment import (
     PFSProjectUsageClientService,
     PFSVMClientService,
 )
+from pfcli.service.client.file import FileClientService, GroupProjectFileClientService
 from pfcli.service.client.group import (
     GroupClientService,
     GroupProjectCheckpointClientService,
@@ -193,6 +194,11 @@ client_template_map: Dict[ServiceType, Tuple[Type[ClientService], Template]] = {
     ServiceType.METRICS: (
         MetricsClientService,
         Template(get_observatory_uri("graphql")),
+    ),
+    ServiceType.FILE: (FileClientService, Template(get_mr_uri("files/"))),
+    ServiceType.GROUP_FILE: (
+        GroupProjectFileClientService,
+        Template(get_mr_uri("orgs/$group_id/$project_id/files/")),
     ),
 }
 

--- a/pfcli/service/client/__init__.py
+++ b/pfcli/service/client/__init__.py
@@ -198,7 +198,7 @@ client_template_map: Dict[ServiceType, Tuple[Type[ClientService], Template]] = {
     ServiceType.FILE: (FileClientService, Template(get_mr_uri("files/"))),
     ServiceType.GROUP_FILE: (
         GroupProjectFileClientService,
-        Template(get_mr_uri("orgs/$group_id/$project_id/files/")),
+        Template(get_mr_uri("orgs/$group_id/prjs/$project_id/files/")),
     ),
 }
 

--- a/pfcli/service/client/file.py
+++ b/pfcli/service/client/file.py
@@ -20,35 +20,35 @@ from pfcli.service.client.base import (
 class FileClientService(ClientService[UUID]):
     """File client service."""
 
-    def get_misc_file_upload_url(self, misc_file_id: UUID) -> Dict[str, Any]:
+    def get_misc_file_upload_url(self, misc_file_id: UUID) -> str:
         """Get an URL to upload file.
 
         Args:
             misc_file_id (UUID): Misc file ID to upload.
 
         Returns:
-            Dict[str, Any]: File info with the uploadable URL.
+            str: An uploadable URL.
 
         """
         response = safe_request(self.post, err_prefix="Failed to get file upload URL.")(
             path=f"{misc_file_id}/upload/"
         )
-        return response.json()
+        return response.json()["upload_url"]
 
-    def get_misc_file_download_url(self, misc_file_id: UUID) -> Dict[str, Any]:
+    def get_misc_file_download_url(self, misc_file_id: UUID) -> str:
         """Get an URL to download file.
 
         Args:
             misc_file_id (UUID): Misc file ID to download.
 
         Returns:
-            Dict[str, Any]: File info with the downloadable URL.
+            Dict[str, Any]: A downloadable URL.
 
         """
         response = safe_request(
             self.post, err_prefix="Failed to get file download URL."
         )(path=f"{misc_file_id}/download/")
-        return response.json()
+        return response.json()["download_url"]
 
     def make_misc_file_uploaded(self, misc_file_id: UUID) -> Dict[str, Any]:
         """Request to mark the file as uploaded.
@@ -62,7 +62,7 @@ class FileClientService(ClientService[UUID]):
         """
         response = safe_request(
             self.partial_update, err_prefix="Failed to patch the file status."
-        )(path=f"{misc_file_id}/uploaded/")
+        )(pk=misc_file_id, path="uploaded/")
         return response.json()
 
 

--- a/pfcli/service/client/file.py
+++ b/pfcli/service/client/file.py
@@ -1,0 +1,102 @@
+# Copyright (C) 2022 FriendliAI
+
+"""PeriFlow File Service."""
+
+from __future__ import annotations
+
+from string import Template
+from typing import Any, Dict
+from uuid import UUID
+
+from pfcli.service.client.base import (
+    ClientService,
+    GroupRequestMixin,
+    ProjectRequestMixin,
+    UserRequestMixin,
+    safe_request,
+)
+
+
+class FileClientService(ClientService[UUID]):
+    """File client service."""
+
+    def get_misc_file_upload_url(self, misc_file_id: UUID) -> Dict[str, Any]:
+        """Get an URL to upload file.
+
+        Args:
+            misc_file_id (UUID): Misc file ID to upload.
+
+        Returns:
+            Dict[str, Any]: File info with the uploadable URL.
+
+        """
+        response = safe_request(self.post, err_prefix="Failed to get file upload URL.")(
+            path=f"{misc_file_id}/upload/"
+        )
+        return response.json()
+
+    def get_misc_file_download_url(self, misc_file_id: UUID) -> Dict[str, Any]:
+        """Get an URL to download file.
+
+        Args:
+            misc_file_id (UUID): Misc file ID to download.
+
+        Returns:
+            Dict[str, Any]: File info with the downloadable URL.
+
+        """
+        response = safe_request(
+            self.post, err_prefix="Failed to get file download URL."
+        )(path=f"{misc_file_id}/download/")
+        return response.json()
+
+    def make_misc_file_uploaded(self, misc_file_id: UUID) -> Dict[str, Any]:
+        """Request to mark the file as uploaded.
+
+        Args:
+            misc_file_id (UUID): Misc file ID to change status.
+
+        Returns:
+            Dict[str, Any]: The updated file info.
+
+        """
+        response = safe_request(
+            self.partial_update, err_prefix="Failed to patch the file status."
+        )(path=f"{misc_file_id}/uploaded/")
+        return response.json()
+
+
+class GroupProjectFileClientService(
+    ClientService, UserRequestMixin, GroupRequestMixin, ProjectRequestMixin
+):
+    """Group-shared file client."""
+
+    def __init__(self, template: Template, **kwargs):
+        self.initialize_user()
+        self.initialize_group()
+        self.initialize_project()
+        super().__init__(
+            template,
+            group_id=self.group_id,
+            project_id=self.project_id,
+            **kwargs,
+        )
+
+    def create_misc_file(self, file_info: Dict[str, Any]) -> Dict[str, Any]:
+        """Request to create a misc file.
+
+        Args:
+            file_info (Dict[str, Any]): File info.
+
+        Returns:
+            Dict[str, Any]: Response body with the created file info.
+
+        """
+        request_data = {
+            "user_id": str(self.user_id),
+            **file_info,
+        }
+        response = safe_request(self.post, err_prefix="Failed to create file.")(
+            json=request_data
+        )
+        return response.json()

--- a/pfcli/service/formatter.py
+++ b/pfcli/service/formatter.py
@@ -64,6 +64,7 @@ class ListFormatter(Formatter):
     headers: List[str]
     extra_fields: List[str] = field(default_factory=list)
     extra_headers: List[str] = field(default_factory=list)
+    substitute_only_exact_match: bool = True
 
     def __post_init__(self):
         super().__post_init__()
@@ -88,8 +89,13 @@ class ListFormatter(Formatter):
         self._substitution_rule[before] = after
 
     def _substitute(self, val: str) -> str:
-        if val in self._substitution_rule:
-            return self._substitution_rule[val]
+        if self.substitute_only_exact_match:
+            if val in self._substitution_rule:
+                return self._substitution_rule[val]
+        else:
+            for before, after in self._substitution_rule.items():
+                if before in val:
+                    return val.replace(before, after)
         return val
 
 

--- a/pfcli/service/formatter.py
+++ b/pfcli/service/formatter.py
@@ -64,7 +64,7 @@ class ListFormatter(Formatter):
     headers: List[str]
     extra_fields: List[str] = field(default_factory=list)
     extra_headers: List[str] = field(default_factory=list)
-    substitute_only_exact_match: bool = True
+    substitute_exact_match_only: bool = True
 
     def __post_init__(self):
         super().__post_init__()
@@ -89,10 +89,12 @@ class ListFormatter(Formatter):
         self._substitution_rule[before] = after
 
     def _substitute(self, val: str) -> str:
-        if self.substitute_only_exact_match:
+        if self.substitute_exact_match_only:
+            # Substitute only when `val` exactly matches to a rule.
             if val in self._substitution_rule:
                 return self._substitution_rule[val]
         else:
+            # Apply substitution for all matched substrings.
             for before, after in self._substitution_rule.items():
                 if before in val:
                     return val.replace(before, after)

--- a/test/service/client/conftest.py
+++ b/test/service/client/conftest.py
@@ -1,0 +1,12 @@
+# Copyright (C) 2021 FriendliAI
+
+"""Common fixtures for client testing."""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture
+def fake_s3_presigned_url() -> str:
+    return "https://my-example-bucket.s3.us-east-1.amazonaws.com/my-example-object?AWSAccessKeyId=AKIAEFGHIJKLMNOPQ123"

--- a/test/service/client/test_file.py
+++ b/test/service/client/test_file.py
@@ -1,0 +1,159 @@
+# Copyright (C) 2022 FriendliAI
+
+"""Unit test for file client."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import Iterator
+from uuid import uuid4
+
+import pytest
+import requests_mock
+import typer
+
+from pfcli.service import ServiceType
+from pfcli.service.client import build_client
+from pfcli.service.client.file import FileClientService, GroupProjectFileClientService
+
+
+@pytest.fixture
+def file_client() -> FileClientService:
+    client = build_client(ServiceType.FILE)
+    assert isinstance(client, FileClientService)
+    return client
+
+
+@pytest.fixture
+def group_file_client(
+    user_project_group_context: Iterator[None],
+) -> GroupProjectFileClientService:
+    client = build_client(ServiceType.GROUP_FILE)
+    assert isinstance(client, GroupProjectFileClientService)
+    return client
+
+
+class TestFileClient:
+    """Unit test for `FileClientService`."""
+
+    @pytest.mark.usefixtures("patch_auto_token_refresh")
+    def test_get_misc_file_upload_url(
+        self,
+        requests_mock: requests_mock.Mocker,
+        file_client: FileClientService,
+        fake_s3_presigned_url: str,
+    ):
+        misc_file_id = uuid4()
+        resp_body = {
+            "upload_url": fake_s3_presigned_url,
+        }
+        base_url = file_client.url_template.get_base_url()
+
+        requests_mock.post(
+            f"{base_url}/files/{misc_file_id}/upload/",
+            json=resp_body,
+        )
+        assert (
+            file_client.get_misc_file_upload_url(misc_file_id=misc_file_id)
+            == fake_s3_presigned_url
+        )
+
+        requests_mock.post(f"{base_url}/files/{misc_file_id}/upload/", status_code=404)
+        with pytest.raises(typer.Exit):
+            file_client.get_misc_file_upload_url(misc_file_id=misc_file_id)
+
+    @pytest.mark.usefixtures("patch_auto_token_refresh")
+    def test_get_misc_file_download_url(
+        self,
+        requests_mock: requests_mock.Mocker,
+        file_client: FileClientService,
+        fake_s3_presigned_url: str,
+    ):
+        misc_file_id = uuid4()
+        resp_body = {
+            "download_url": fake_s3_presigned_url,
+        }
+        base_url = file_client.url_template.get_base_url()
+
+        requests_mock.post(
+            f"{base_url}/files/{misc_file_id}/download/",
+            json=resp_body,
+        )
+        assert (
+            file_client.get_misc_file_download_url(misc_file_id=misc_file_id)
+            == fake_s3_presigned_url
+        )
+
+        requests_mock.post(
+            f"{base_url}/files/{misc_file_id}/download/", status_code=404
+        )
+        with pytest.raises(typer.Exit):
+            file_client.get_misc_file_download_url(misc_file_id=misc_file_id)
+
+    @pytest.mark.usefixtures("patch_auto_token_refresh")
+    def test_make_misc_file_uploaded(
+        self,
+        requests_mock: requests_mock.Mocker,
+        file_client: FileClientService,
+    ):
+        misc_file_id = uuid4()
+        resp_body = {
+            "id": str(uuid4()),
+            "name": "string",
+            "path": "string",
+            "mtime": "2023-03-31T06:29:58.703Z",
+            "size": 0,
+            "uploaded": True,
+            "organization_id": str(uuid4()),
+            "project_id": str(uuid4()),
+            "user_id": str(uuid4()),
+        }
+        base_url = file_client.url_template.get_base_url()
+
+        requests_mock.patch(
+            f"{base_url}/files/{misc_file_id}/uploaded/",
+            json=resp_body,
+        )
+        assert (
+            file_client.make_misc_file_uploaded(misc_file_id=misc_file_id) == resp_body
+        )
+
+        requests_mock.patch(
+            f"{base_url}/files/{misc_file_id}/uploaded/", status_code=404
+        )
+        with pytest.raises(typer.Exit):
+            file_client.make_misc_file_uploaded(misc_file_id=misc_file_id)
+
+
+class TestGroupProjectFileClient:
+    """Unit test for `GroupProjectFileClientService`."""
+
+    @pytest.mark.usefixtures("patch_auto_token_refresh")
+    def test_make_create_misc_file(
+        self,
+        requests_mock: requests_mock.Mocker,
+        group_file_client: GroupProjectFileClientService,
+    ):
+        resp_body = {
+            "id": str(uuid4()),
+            "name": "string",
+            "path": "string",
+            "mtime": "2023-03-31T06:29:58.703Z",
+            "size": 0,
+            "uploaded": False,
+            "organization_id": str(uuid4()),
+            "project_id": str(uuid4()),
+            "user_id": str(uuid4()),
+        }
+        url = group_file_client.url_template.render(**group_file_client.url_kwargs)
+        file_info = {}
+
+        requests_mock.post(
+            url,
+            json=resp_body,
+        )
+        assert group_file_client.create_misc_file(file_info=file_info) == resp_body
+
+        requests_mock.post(url, status_code=409)
+        with pytest.raises(typer.Exit):
+            group_file_client.create_misc_file(file_info=file_info)


### PR DESCRIPTION
- [x] Visualize deployment status in styled format for `pf deployment list` and `pf deployment view` commands.
- [x] `--default-request-request-config` option is added to `pf deployment create` command. By using this option, users can create a deployment with setting a default request configuration that can preprocess the contents of the request payload (e.g., excluding bad words or stopwords from the request body).
- [x] Unit tests.