### PR TITLE
Minor fix on billing summary command default value

### DIFF
--- a/pfcli/billing.py
+++ b/pfcli/billing.py
@@ -113,7 +113,7 @@ def summary(
     year: int = typer.Argument(...),
     month: int = typer.Argument(...),
     day: Optional[int] = typer.Argument(None),
-    scope: Scope = typer.Option(Scope.USR, "--scope", help="Scope of the summary."),
+    scope: Scope = typer.Option(Scope.USR.value, "--scope", help="Scope of the summary."),
     time_granularity: Optional[TimeGranularity] = typer.Option(
         None, "--time-granularity", "-t", help="View within the given time granularity."
     ),

--- a/pfcli/billing.py
+++ b/pfcli/billing.py
@@ -113,7 +113,9 @@ def summary(
     year: int = typer.Argument(...),
     month: int = typer.Argument(...),
     day: Optional[int] = typer.Argument(None),
-    scope: Scope = typer.Option(Scope.USR.value, "--scope", help="Scope of the summary."),
+    scope: Scope = typer.Option(
+        Scope.USR.value, "--scope", help="Scope of the summary."
+    ),
     time_granularity: Optional[TimeGranularity] = typer.Option(
         None, "--time-granularity", "-t", help="View within the given time granularity."
     ),

--- a/pfcli/deployment.py
+++ b/pfcli/deployment.py
@@ -233,7 +233,9 @@ deployment_table.add_substitution_rule(
 )
 deployment_table.add_substitution_rule("Terminated", "[bold]Terminated[/bold]")
 
-deployment_org_table.add_substitution_rule("Pending", "[bold yellow]Pending[/bold yellow]")
+deployment_org_table.add_substitution_rule(
+    "Pending", "[bold yellow]Pending[/bold yellow]"
+)
 deployment_org_table.add_substitution_rule(
     "Initializing", "[bold cyan]Initializing[/bold cyan]"
 )


### PR DESCRIPTION
Before:

```
  --scope [organization|project|user]
                                  Scope of the summary.  [default: Scope.USR]
```


After:

```
  --scope [organization|project|user]
                                  Scope of the summary.  [default: user]
```