### PR TITLE
Renew deploy status

### DIFF
--- a/pfcli/deployment.py
+++ b/pfcli/deployment.py
@@ -237,8 +237,12 @@ deployment_table.add_substitution_rule("Terminated", "[bold]Terminated[/bold]")
 deployment_org_table.add_substitution_rule(
     "Initializing", "[bold yellow]Initializing[/bold yellow]"
 )
-deployment_org_table.add_substitution_rule("Healthy", "[bold green]Healthy[/bold green]")
-deployment_org_table.add_substitution_rule("Unhealthy", "[bold red]Unhealthy[/bold red]")
+deployment_org_table.add_substitution_rule(
+    "Healthy", "[bold green]Healthy[/bold green]"
+)
+deployment_org_table.add_substitution_rule(
+    "Unhealthy", "[bold red]Unhealthy[/bold red]"
+)
 deployment_org_table.add_substitution_rule(
     "Stopping", "[bold magenta]Stopping[/bold magenta]"
 )

--- a/pfcli/deployment.py
+++ b/pfcli/deployment.py
@@ -5,7 +5,6 @@
 from __future__ import annotations
 
 import ast
-import json
 import os
 from datetime import datetime, timedelta, timezone
 from typing import Any, Dict, Optional
@@ -215,33 +214,31 @@ deployment_event_table = TableFormatter(
     headers=["ID", "Type", "Description", "Timestamp"],
 )
 
-deployment_panel.add_substitution_rule("Pending", "[bold yellow]Pending[/bold yellow]")
 deployment_panel.add_substitution_rule(
-    "Initializing", "[bold cyan]Initializing[/bold cyan]"
+    "Initializing", "[bold yellow]Initializing[/bold yellow]"
 )
-deployment_panel.add_substitution_rule("Running", "[bold blue]Running[/bold blue]")
+deployment_panel.add_substitution_rule("Healthy", "[bold green]Healthy[/bold green]")
+deployment_panel.add_substitution_rule("Unhealthy", "[bold red]Unhealthy[/bold red]")
 deployment_panel.add_substitution_rule(
     "Stopping", "[bold magenta]Stopping[/bold magenta]"
 )
 deployment_panel.add_substitution_rule("Terminated", "[bold]Terminated[/bold]")
 
-deployment_table.add_substitution_rule("Pending", "[bold yellow]Pending[/bold yellow]")
 deployment_table.add_substitution_rule(
-    "Initializing", "[bold cyan]Initializing[/bold cyan]"
+    "Initializing", "[bold yellow]Initializing[/bold yellow]"
 )
-deployment_table.add_substitution_rule("Running", "[bold blue]Running[/bold blue]")
+deployment_table.add_substitution_rule("Healthy", "[bold green]Healthy[/bold green]")
+deployment_table.add_substitution_rule("Unhealthy", "[bold red]Unhealthy[/bold red]")
 deployment_table.add_substitution_rule(
     "Stopping", "[bold magenta]Stopping[/bold magenta]"
 )
 deployment_table.add_substitution_rule("Terminated", "[bold]Terminated[/bold]")
 
 deployment_org_table.add_substitution_rule(
-    "Pending", "[bold yellow]Pending[/bold yellow]"
+    "Initializing", "[bold yellow]Initializing[/bold yellow]"
 )
-deployment_org_table.add_substitution_rule(
-    "Initializing", "[bold cyan]Initializing[/bold cyan]"
-)
-deployment_org_table.add_substitution_rule("Running", "[bold blue]Running[/bold blue]")
+deployment_org_table.add_substitution_rule("Healthy", "[bold green]Healthy[/bold green]")
+deployment_org_table.add_substitution_rule("Unhealthy", "[bold red]Unhealthy[/bold red]")
 deployment_org_table.add_substitution_rule(
     "Stopping", "[bold magenta]Stopping[/bold magenta]"
 )
@@ -291,7 +288,6 @@ def list(
         deployment["vms"] = (
             deployment["vms"][0]["name"] if deployment["vms"] else "None"
         )
-        deployment["status"] = ", ".join(deployment["status"])
         deployment["deployment_id"] = get_deployment_id_from_namespace(
             deployment["namespace"]
         )
@@ -319,7 +315,7 @@ def delete(deployment_id: str = typer.Argument(..., help="ID of deployment to de
     client.delete_deployment(deployment_id)
     typer.secho(
         f"Deleted Deployment ({deployment_id}) successfully.",
-        fg=typer.colors.BLUE,
+        fg=typer.colors.green,
     )
 
 
@@ -343,7 +339,6 @@ def view(
         if deployment["config"]["infrequest_perm_check"]
         else DeploymentSecurityLevel.PUBLIC.value
     )
-    deployment["status"] = ", ".join(deployment["status"])
     deployment["deployment_id"] = get_deployment_id_from_namespace(
         deployment["namespace"]
     )
@@ -579,7 +574,7 @@ def create(
     typer.secho(
         f"Deployment ({deployment_id}) started successfully. Use 'pf deployment view {deployment_id}' to see the deployment details.\n"
         f"Send inference requests to '{deployment['endpoint']}'.",
-        fg=typer.colors.BLUE,
+        fg=typer.colors.green,
     )
 
 
@@ -595,7 +590,7 @@ def update(
     client.update_deployment_scaler(deployment_id=deployment_id, scaler=scaler)
     typer.secho(
         f"Scaler of deployment ({deployment_id}) is updated.\n" f"Scaler: {scaler}.",
-        fg=typer.colors.BLUE,
+        fg=typer.colors.green,
     )
 
 


### PR DESCRIPTION
Instead of using the respective replica status to represent the deployment status, we clean up the deployment status as follows:

- Initializing: Deployment is initializing to serve the requests. This state is sustained from the point when the deployment is created by `pf deployment create` command to the point when any inference server replica is ready to handle the request.
- Healthy: Deployment can handle requests. This state is valid as long as any inference server replica is ready to handle requests.
- Unhealthy: Deployment is running but cannot handle requests. This state means that all inference server replica is not ready to handle requests due to some problem (regardless of their recoverability).
- Stopping: Deployment is in the termination process. This state is set when `pf deployment delete` command is executed and is changed to "Terminated" status when the deployment resources are actually shut down.
- Terminated: Deployment is completely terminated.