### PR TITLE
Show checkpoint status: "Active", "Soft-Deleted", "Hard-Deleted"

### DIFF
--- a/pfcli/checkpoint.py
+++ b/pfcli/checkpoint.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 import os
+from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, Optional
 from uuid import UUID
@@ -180,14 +181,20 @@ blender_model_info_panel = PanelFormatter(
 def determine_checkpoint_status(data: Dict[str, Any]) -> None:
     """Given the checkpoint info, inplace update the status."""
     if data["hard_deleted"]:
+        hard_deleted_at = datetime.strftime(
+            parse(data["hard_deleted_at"]), "%Y-%m-%d %H:%M:%S"
+        )
         typer.secho(
-            f"This checkpoint is hard-deleted. You cannot use this checkpoint.",
+            f"This checkpoint was hard-deleted at {hard_deleted_at}. "
+            "You cannot use this checkpoint.",
             fg=typer.colors.RED,
         )
         data["status"] = "[bold red]Hard-Deleted"
     elif data["deleted"]:
+        deleted_at = datetime.strftime(parse(data["deleted_at"]), "%Y-%m-%d %H:%M:%S")
         typer.secho(
-            f"This is a deleted checkpoint. Please restore it if you want use this.",
+            f"This checkpoint was deleted at {deleted_at}. "
+            "Please restore it if you want use this.",
             fg=typer.colors.YELLOW,
         )
         data["status"] = "[bold yellow]Soft-Deleted"

--- a/pfcli/utils/url.py
+++ b/pfcli/utils/url.py
@@ -6,14 +6,14 @@ from __future__ import annotations
 
 from urllib.parse import urljoin
 
-periflow_api_server = "https://api-dev.friendli.ai/api/"
-periflow_ws_server = "wss://api-ws-dev.friendli.ai/ws/"
+periflow_api_server = "https://api-staging.friendli.ai/api/"
+periflow_ws_server = "wss://api-ws-staging.friendli.ai/ws/"
 periflow_discuss_url = "https://discuss.friendli.ai/"
-periflow_mr_server = "https://pfmodelregistry-dev.friendli.ai/"
-periflow_serve_server = "https://pfs-dev.friendli.ai/"
-periflow_auth_server = "https://pfauth-dev.friendli.ai/"
-periflow_meter_server = "https://pfmeter-dev.friendli.ai/"
-periflow_observatory_server = "https://pfo-dev.friendli.ai/"
+periflow_mr_server = "https://pfmodelregistry-staging.friendli.ai/"
+periflow_serve_server = "https://pfs-staging.friendli.ai/"
+periflow_auth_server = "https://pfauth-staging.friendli.ai/"
+periflow_meter_server = "https://pfmeter-staging.friendli.ai/"
+periflow_observatory_server = "https://pfo-staging.friendli.ai/"
 
 
 def get_auth_uri(path: str) -> str:

--- a/pfcli/utils/url.py
+++ b/pfcli/utils/url.py
@@ -6,14 +6,14 @@ from __future__ import annotations
 
 from urllib.parse import urljoin
 
-periflow_api_server = "https://api-staging.friendli.ai/api/"
-periflow_ws_server = "wss://api-ws-staging.friendli.ai/ws/"
+periflow_api_server = "https://api-dev.friendli.ai/api/"
+periflow_ws_server = "wss://api-ws-dev.friendli.ai/ws/"
 periflow_discuss_url = "https://discuss.friendli.ai/"
-periflow_mr_server = "https://pfmodelregistry-staging.friendli.ai/"
-periflow_serve_server = "https://pfs-staging.friendli.ai/"
-periflow_auth_server = "https://pfauth-staging.friendli.ai/"
-periflow_meter_server = "https://pfmeter-staging.friendli.ai/"
-periflow_observatory_server = "https://pfo-staging.friendli.ai/"
+periflow_mr_server = "https://pfmodelregistry-dev.friendli.ai/"
+periflow_serve_server = "https://pfs-dev.friendli.ai/"
+periflow_auth_server = "https://pfauth-dev.friendli.ai/"
+periflow_meter_server = "https://pfmeter-dev.friendli.ai/"
+periflow_observatory_server = "https://pfo-dev.friendli.ai/"
 
 
 def get_auth_uri(path: str) -> str:

--- a/test/service/client/test_deployment.py
+++ b/test/service/client/test_deployment.py
@@ -100,9 +100,12 @@ def test_deployment_client_list_deployment(
         ),
         json=results,
     )
-    assert deployment_client.list_deployments(
-        project_id=1, archived=False, limit=2, from_oldest=False
-    ) == results["deployments"]
+    assert (
+        deployment_client.list_deployments(
+            project_id=1, archived=False, limit=2, from_oldest=False
+        )
+        == results["deployments"]
+    )
 
     # Failed due to HTTP error
     requests_mock.get(


### PR DESCRIPTION
This PR makes the checkpoint info panel include the checkpoint status info. The possible statuses are as follows.

- `Active`: Checkpoint which is not deleted and available to use in job or deployment.

<img width="1437" alt="image" src="https://github.com/friendliai/periflow-cli/assets/17061663/a58393fb-b220-4824-a9df-312e08a51d00">

- `Soft-Deleted`: Checkpoint which is soft-deleted. The soft-deleted checkpoint can be restored within 24 hours after the deletion.

<img width="1434" alt="image" src="https://github.com/friendliai/periflow-cli/assets/17061663/0638ffb3-38fa-46e5-9d43-c69ec54817da">

- `Hard-Deleted`: Checkpoint which is hard-deleted. The hard-deleted checkpoint never can be restored.

<img width="1432" alt="image" src="https://github.com/friendliai/periflow-cli/assets/17061663/0b3a0b01-a6d6-43ad-ac0b-feb727efac52">


